### PR TITLE
Completable and Single [Part 2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A miniature reactive Android library.
 
 - `Completable`: The simplest of the reactive API, this observable only allows three events, `onStart`, `onComplete`, and `onError`.
 - `Single`: A sort of extension of the `Completable`, this observable emits the same three events as well as an `onItem` event that only emits a single item.
-- `Observable`: A more complex extension of the `Completable`, this observable emits the same three events as well as an `onNext` event that can be called multiple times to emit multiple items.
-- `CompletableAction`, `SingleAction`, `ObservableAction`: Work that you wish to perform when the user subscribes to your observable. `Action.onSubscribe` is called when the user subscribes to the observable. The work is run on the Scheduler specified by the `Observable.subscribeOn` method.
-- `CompletableSubscriber`, `SingleSubscriber`, `ObservableSubscriber`/`CompletableOnSubscribe`, `SingleOnSubscribe`, `ObservableOnSubscribe`: The consumer of the observable is the Subscriber. There are two classes describing this in order to separate communication between the subscriber thread (where the work is done) and the observer thread (where it is emitted). Subscriber is used by the subscriber thread to pass events to the OnSubscribe implementation (provided by ths subscriber), which is called on the observe thread.
+- `Stream`: A more complex extension of the `Completable`, this observable emits the same three events as well as an `onNext` event that can be called multiple times to emit multiple items.
+- `CompletableAction`, `SingleAction`, `StreamAction`: Work that you wish to perform when the user subscribes to your observable. `Action.onSubscribe` is called when the user subscribes to the observable. The work is run on the Scheduler specified by the `observable.subscribeOn` method.
+- `CompletableSubscriber`, `SingleSubscriber`, `StreamSubscriber`/`CompletableOnSubscribe`, `SingleOnSubscribe`, `StreamOnSubscribe`: The consumer of the observable is the Subscriber. There are two classes describing this in order to separate communication between the subscriber thread (where the work is done) and the observer thread (where it is emitted). Subscriber is used by the subscriber thread to pass events to the OnSubscribe implementation (provided by ths subscriber), which is called on the observe thread.
     - `onStart()`: Always called when the observable starts (called internally)
     - `onNext(T item)`: Called by the observable if it has an item to pass to you
     - `onComplete()`: Should be called by the observable when it is done emitting items, this will release the resources used by the observable/subscription unless they are held elsewhere. Not calling this indicates that the observable has more items to emit.
@@ -35,9 +35,9 @@ A miniature reactive Android library.
 
 ##### Basic example
 ```java
-Observable.create(new ObservableAction<String>() {
+Stream.create(new StreamAction<String>() {
     @Override
-    public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+    public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
         subscriber.onNext("string 1");
         subscriber.onNext("string 2");
         subscriber.onNext("string 3");
@@ -45,7 +45,7 @@ Observable.create(new ObservableAction<String>() {
     }
 }).subscribeOn(Schedulers.io())
   .observeOn(Schedulers.main())
-  .subscribe(new ObservableOnSubscribe<String>() {
+  .subscribe(new StreamOnSubscribe<String>() {
         @Override
         public void onNext(String item) {
             Log.d(TAG, "Asynchronously received this string: " + item);
@@ -67,10 +67,10 @@ private Subscription subscription;
  * as the Subscriber is subscribed to it. Fibonacci numbers are
  * Emitted every half a second.
  */
-private Observable<Integer> allFibonacciNumbersObservable() {
-    return Observable.create(new ObservableAction<Integer>() {
+private Stream<Integer> allFibonacciNumbersStream() {
+    return Stream.create(new StreamAction<Integer>() {
         @Override
-        public void onSubscribe(@NonNull ObservableSubscriber<Integer> subscriber) {
+        public void onSubscribe(@NonNull StreamSubscriber<Integer> subscriber) {
             int firstNumber = 0;
             int secondNumber = 1;
             int temp;
@@ -93,10 +93,10 @@ private Observable<Integer> allFibonacciNumbersObservable() {
 }
 
 private void doWorkOnMainThread() {
-    subscription = allFibonacciNumbersObservable()
+    subscription = allFibonacciNumbersStream()
         .subscribeOn(Schedulers.worker())
         .observeOn(Schedulers.main())
-        .subscribe(new ObservableOnSubscribe<Integer>() {
+        .subscribe(new StreamOnSubscribe<Integer>() {
             @Override
             public void onStart() {
                 Log.d(TAG, "Started receiving numbers");
@@ -126,9 +126,9 @@ public void onDestroy() {
 ##### List Example
 ```java
 final List<String> list = new ArrayList();
-Observable.create(new ObservableAction<List<String>>() {
+Stream.create(new StreamAction<List<String>>() {
     @Override
-    public void onSubscribe(@NonNull ObservableSubscriber<List<String>> subscriber) {
+    public void onSubscribe(@NonNull StreamSubscriber<List<String>> subscriber) {
         List<String> stringList = new ArrayList<>();
         stringList.add("string 1");
         stringList.add("string 2");
@@ -138,7 +138,7 @@ Observable.create(new ObservableAction<List<String>>() {
     }
 }).subscribeOn(Schedulers.current())
   .observeOn(Schedulers.current())
-  .subscribe(new ObservableOnSubscribe<List<String>>() {
+  .subscribe(new StreamOnSubscribe<List<String>>() {
         @Override
         public void onNext(List<String> item) {
             list.addAll(item);

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ A miniature reactive Android library.
 
 ### The API
 
-- `Observable`: A manager class that handles communication between an `Action` and a `Subscriber` by scheduling events to occur on different threads using a `Scheduler`
-- `Action`: Work that you wish to perform when the user subscribes to your observable. `Action.onSubscribe` is called when the user subscribes to the Observable. The work is run on the Scheduler specified by the `Observable.subscribeOn` method.
-- `Subscriber`, `OnSubscribe`: The consumer of the observable is the Subscriber. There are two classes describing this in order to separate communication between the subscriber thread (where the work is done) and the observer thread (where it is emitted). Subscriber is used by the subscriber thread to pass events to the OnSubscribe implementation (provided by ths subscriber), which is called on the observe thread.
+- `Completable`: The simplest of the reactive API, this observable only allows three events, `onStart`, `onComplete`, and `onError`.
+- `Single`: A sort of extension of the `Completable`, this observable emits the same three events as well as an `onItem` event that only emits a single item.
+- `Observable`: A more complex extension of the `Completable`, this observable emits the same three events as well as an `onNext` event that can be called multiple times to emit multiple items.
+- `CompletableAction`, `SingleAction`, `ObservableAction`: Work that you wish to perform when the user subscribes to your observable. `Action.onSubscribe` is called when the user subscribes to the observable. The work is run on the Scheduler specified by the `Observable.subscribeOn` method.
+- `CompletableSubscriber`, `SingleSubscriber`, `ObservableSubscriber`/`CompletableOnSubscribe`, `SingleOnSubscribe`, `ObservableOnSubscribe`: The consumer of the observable is the Subscriber. There are two classes describing this in order to separate communication between the subscriber thread (where the work is done) and the observer thread (where it is emitted). Subscriber is used by the subscriber thread to pass events to the OnSubscribe implementation (provided by ths subscriber), which is called on the observe thread.
     - `onStart()`: Always called when the observable starts (called internally)
-    - `onNext(T item)`: Called by the Observable if it has an item to pass to you
-    - `onComplete()`: Should be called by the Observable when it is done emitting items, this will release the resources used by the Observable/Subscription unless they are held elsewhere. Not calling this indicates that the Observable has more items to emit.
-    - `onError(Exception exception)`: The Observable should call this if an error occurs. If this method is called, onComplete or onNext should not be called. This method will also be called automatically if your onSubscribe method throws an exception.
+    - `onNext(T item)`: Called by the observable if it has an item to pass to you
+    - `onComplete()`: Should be called by the observable when it is done emitting items, this will release the resources used by the observable/subscription unless they are held elsewhere. Not calling this indicates that the observable has more items to emit.
+    - `onError(Exception exception)`: The observable should call this if an error occurs. If this method is called, onComplete or onNext should not be called. This method will also be called automatically if your onSubscribe method throws an exception.
 - `Scheduler`: A thin wrapper around a thread that schedules work to be done.
 - `Schedulers`: A utility class that creates `Scheduler` instances for you. See below for a list of provided ones:
     - `io()`: A single thread that you should reserve for talking to disk. Android disk IO is single threaded for write operations, which is why one thread is used here.
@@ -27,7 +29,7 @@ A miniature reactive Android library.
     - `newSingleThreadScheduler()`: Creates a new single thread scheduler (like the `io()` scheduler).
     - `current()`: Runs work on the thread that this method was called on.
     - `from(Executor)`: Allows you to construct a scheduler backed by an `Executor` of your choice.
-- `Subscription`: This is returned when you subscribe to an Observable. It allows you to unsubscribe from the work. If you unsubscribe, you will no longer receive events. This is especially helpful in Android if we are observing long lasting work in an Activity, we want to unsubscribe in `Activity.onDestroy()` in order to avoid leaking the Activity.
+- `Subscription`: This is returned when you subscribe to an observable. It allows you to unsubscribe from the work. If you unsubscribe, you will no longer receive events. This is especially helpful in Android if we are observing long lasting work in an Activity, we want to unsubscribe in `Activity.onDestroy()` in order to avoid leaking the Activity.
 
 ### How to use
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A miniature reactive Android library.
 
 ### The API
 
-- `Completable`: The simplest of the reactive API, this observable only allows three events, `onStart`, `onComplete`, and `onError`.
+- `Completable`: The simplest of the reactive API, this observable emits only three events, `onStart`, `onComplete`, and `onError`.
 - `Single`: A sort of extension of the `Completable`, this observable emits the same three events as well as an `onItem` event that only emits a single item.
 - `Stream`: A more complex extension of the `Completable`, this observable emits the same three events as well as an `onNext` event that can be called multiple times to emit multiple items.
 - `CompletableAction`, `SingleAction`, `StreamAction`: Work that you wish to perform when the user subscribes to your observable. `Action.onSubscribe` is called when the user subscribes to the observable. The work is run on the Scheduler specified by the `observable.subscribeOn` method.

--- a/library/src/main/java/com/anthonycr/bonsai/Completable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Completable.java
@@ -115,16 +115,7 @@ public class Completable {
      * ignores all onComplete calls.
      */
     public void subscribe() {
-        executeOnSubscriberThread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    action.onSubscribe(new Completable.SubscriberImpl(null, Completable.this));
-                } catch (Exception exception) {
-                    // Do nothing because we don't have a subscriber
-                }
-            }
-        });
+        startSubscription(null);
     }
 
     /**
@@ -137,9 +128,13 @@ public class Completable {
      */
     @NonNull
     public Subscription subscribe(@NonNull CompletableOnSubscribe onSubscribe) {
-
         Preconditions.checkNonNull(onSubscribe);
 
+        return startSubscription(onSubscribe);
+    }
+
+    @NonNull
+    private Subscription startSubscription(@Nullable CompletableOnSubscribe onSubscribe) {
         final CompletableSubscriber subscriber = new Completable.SubscriberImpl(onSubscribe, this);
 
         subscriber.onStart();

--- a/library/src/main/java/com/anthonycr/bonsai/Completable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Completable.java
@@ -130,7 +130,7 @@ public class Completable {
     /**
      * Immediately subscribes to the Completable and starts
      * sending events from the Completable to the
-     * {@link ObservableOnSubscribe}.
+     * {@link StreamOnSubscribe}.
      *
      * @param onSubscribe the class that wishes to receive onComplete
      *                    callbacks from the Completable.

--- a/library/src/main/java/com/anthonycr/bonsai/Completable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Completable.java
@@ -178,6 +178,7 @@ public class Completable {
 
         @Nullable private volatile CompletableOnSubscribe onSubscribe;
         @NonNull private final Completable completable;
+        private boolean onStartExecuted = false;
         private boolean onCompleteExecuted = false;
         private boolean onError = false;
 
@@ -206,8 +207,11 @@ public class Completable {
         @Override
         public void onStart() {
             CompletableOnSubscribe onSubscribe = this.onSubscribe;
-            if (onSubscribe != null) {
+            if (!onStartExecuted && onSubscribe != null) {
+                onStartExecuted = true;
                 completable.executeOnObserverThread(new OnStartRunnable(onSubscribe));
+            } else if (onStartExecuted) {
+                throw new RuntimeException("onStart is called internally, do not call it yourself");
             }
         }
 

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableAction.java
@@ -33,7 +33,7 @@ public interface CompletableAction {
      * events such as {@link CompletableSubscriber#onComplete()}.
      *
      * @param subscriber the subscriber that is sent in
-     *                   when the user of the Observable
+     *                   when the user of the observable
      *                   subscribes.
      */
     void onSubscribe(@NonNull CompletableSubscriber subscriber);

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableOnSubscribe.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableOnSubscribe.java
@@ -39,7 +39,7 @@ public abstract class CompletableOnSubscribe {
      * is dead and no {@link #onComplete()} or other callbacks
      * callbacks will be called. Default implementation
      * throws an exception, so you will get a crash
-     * if the Observable throws an exception and this
+     * if the observable throws an exception and this
      * method is not overridden. Do not call super when
      * you override this method.
      *

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriber.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriber.java
@@ -31,11 +31,11 @@ public interface CompletableSubscriber extends Subscription {
 
     /**
      * Called immediately upon subscribing
-     * and before the Observable begins
+     * and before the observable begins
      * emitting items. This should not be
-     * called by the creator of the Observable
+     * called by the creator of the observable
      * and is rather called internally by the
-     * Observable class itself.
+     * observable class itself.
      */
     void onStart();
 

--- a/library/src/main/java/com/anthonycr/bonsai/OnNextRunnable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/OnNextRunnable.java
@@ -24,10 +24,10 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 class OnNextRunnable<T> implements Runnable {
-    @NonNull private final ObservableOnSubscribe<T> onSubscribe;
+    @NonNull private final StreamOnSubscribe<T> onSubscribe;
     @Nullable private final T item;
 
-    OnNextRunnable(@NonNull ObservableOnSubscribe<T> onSubscribe, @Nullable T item) {
+    OnNextRunnable(@NonNull StreamOnSubscribe<T> onSubscribe, @Nullable T item) {
         this.onSubscribe = onSubscribe;
         this.item = item;
     }

--- a/library/src/main/java/com/anthonycr/bonsai/Schedulers.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Schedulers.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executors;
 
 /**
  * A class of default {@link Scheduler} provided
- * for use with {@link Observable}, {@link Single},
+ * for use with {@link Stream}, {@link Single},
  * and {@link Completable}.
  * <p>
  * If the options available here are not sufficient,

--- a/library/src/main/java/com/anthonycr/bonsai/Single.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Single.java
@@ -133,7 +133,7 @@ public class Single<T> {
 
     /**
      * Immediately subscribes to the Single and starts
-     * sending events from the Single to the {@link ObservableOnSubscribe}.
+     * sending events from the Single to the {@link StreamOnSubscribe}.
      *
      * @param onSubscribe the class that wishes to receive onItem and
      *                    onComplete callbacks from the Single.

--- a/library/src/main/java/com/anthonycr/bonsai/Single.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Single.java
@@ -119,16 +119,7 @@ public class Single<T> {
      * all onComplete and onItem calls.
      */
     public void subscribe() {
-        executeOnSubscriberThread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    action.onSubscribe(new Single.SubscriberImpl<>(null, Single.this));
-                } catch (Exception exception) {
-                    // Do nothing because we don't have a subscriber
-                }
-            }
-        });
+        startSubscription(null);
     }
 
     /**
@@ -140,9 +131,13 @@ public class Single<T> {
      */
     @NonNull
     public Subscription subscribe(@NonNull SingleOnSubscribe<T> onSubscribe) {
-
         Preconditions.checkNonNull(onSubscribe);
 
+        return startSubscription(onSubscribe);
+    }
+
+    @NonNull
+    private Subscription startSubscription(@Nullable SingleOnSubscribe<T> onSubscribe) {
         final SingleSubscriber<T> subscriber = new Single.SubscriberImpl<>(onSubscribe, this);
 
         subscriber.onStart();

--- a/library/src/main/java/com/anthonycr/bonsai/SingleAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/SingleAction.java
@@ -37,7 +37,7 @@ public interface SingleAction<T> {
      * or {@link SingleSubscriber#onComplete()}.
      *
      * @param subscriber the subscriber that is sent in
-     *                   when the user of the Observable
+     *                   when the user of the observable
      *                   subscribes.
      */
     void onSubscribe(@NonNull SingleSubscriber<T> subscriber);

--- a/library/src/main/java/com/anthonycr/bonsai/Stream.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Stream.java
@@ -119,16 +119,7 @@ public class Stream<T> {
      * all onComplete and onNext calls.
      */
     public void subscribe() {
-        executeOnSubscriberThread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    action.onSubscribe(new SubscriberImpl<>(null, Stream.this));
-                } catch (Exception exception) {
-                    // Do nothing because we don't have a subscriber
-                }
-            }
-        });
+        startSubscription(null);
     }
 
     /**
@@ -140,9 +131,13 @@ public class Stream<T> {
      */
     @NonNull
     public Subscription subscribe(@NonNull StreamOnSubscribe<T> onSubscribe) {
-
         Preconditions.checkNonNull(onSubscribe);
 
+        return startSubscription(onSubscribe);
+    }
+
+    @NonNull
+    private Subscription startSubscription(@Nullable StreamOnSubscribe<T> onSubscribe) {
         final StreamSubscriber<T> subscriber = new SubscriberImpl<>(onSubscribe, this);
 
         subscriber.onStart();

--- a/library/src/main/java/com/anthonycr/bonsai/Stream.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Stream.java
@@ -181,6 +181,7 @@ public class Stream<T> {
 
         @Nullable private volatile StreamOnSubscribe<T> onSubscribe;
         @NonNull private final Stream<T> stream;
+        private boolean onStartExecuted = false;
         private boolean onCompleteExecuted = false;
         private boolean onError = false;
 
@@ -209,8 +210,11 @@ public class Stream<T> {
         @Override
         public void onStart() {
             StreamOnSubscribe<T> onSubscribe = this.onSubscribe;
-            if (onSubscribe != null) {
+            if (!onStartExecuted && onSubscribe != null) {
+                onStartExecuted = true;
                 stream.executeOnObserverThread(new OnStartRunnable(onSubscribe));
+            } else if (onStartExecuted) {
+                throw new RuntimeException("onStart is called internally, do not call it yourself");
             }
         }
 

--- a/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
@@ -36,7 +36,7 @@ public interface StreamAction<T> {
      * or {@link StreamSubscriber#onComplete()}.
      *
      * @param subscriber the subscriber that is sent in
-     *                   when the user of the Observable
+     *                   when the user of the observable
      *                   subscribes.
      */
     void onSubscribe(@NonNull StreamSubscriber<T> subscriber);

--- a/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Anthony C. Restaino
+ * Copyright (C) 2017 Anthony C. Restaino
  * <p/>
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,29 +20,24 @@
  */
 package com.anthonycr.bonsai;
 
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
 
 /**
- * When a consumer subscribes to a {@link Observable}
- * it should supply an implementation of this class
- * with the desired methods overridden.
- * If {@link #onError(Throwable)} is not overridden,
- * it will through an exception.
+ * An action to perform when a consumer
+ * subscribes to the {@link Stream}.
  *
- * @param <T> the type that will be emitted by the action.
+ * @param <T> the type the action should emit.
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class ObservableOnSubscribe<T> extends CompletableOnSubscribe {
-
+public interface StreamAction<T> {
     /**
-     * Called when the Observer emits an
-     * item. It can be called multiple times.
-     * It cannot be called after onComplete
-     * has been called.
+     * Should be overridden to send the subscriber
+     * events such as {@link StreamSubscriber#onNext(Object)}
+     * or {@link StreamSubscriber#onComplete()}.
      *
-     * @param item the item that has been emitted,
-     *             can be null.
+     * @param subscriber the subscriber that is sent in
+     *                   when the user of the Observable
+     *                   subscribes.
      */
-    public void onNext(@Nullable T item) {}
-
+    void onSubscribe(@NonNull StreamSubscriber<T> subscriber);
 }

--- a/library/src/main/java/com/anthonycr/bonsai/StreamOnSubscribe.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamOnSubscribe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Anthony C. Restaino
+ * Copyright (C) 2016 Anthony C. Restaino
  * <p/>
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -23,13 +23,16 @@ package com.anthonycr.bonsai;
 import android.support.annotation.Nullable;
 
 /**
- * The interface through which the {@link ObservableAction}
- * communicates to the {@link ObservableOnSubscribe}.
+ * When a consumer subscribes to a {@link Stream}
+ * it should supply an implementation of this class
+ * with the desired methods overridden.
+ * If {@link #onError(Throwable)} is not overridden,
+ * it will through an exception.
  *
- * @param <T> the object type that should be emitted.
+ * @param <T> the type that will be emitted by the action.
  */
 @SuppressWarnings("WeakerAccess")
-public interface ObservableSubscriber<T> extends CompletableSubscriber {
+public abstract class StreamOnSubscribe<T> extends CompletableOnSubscribe {
 
     /**
      * Called when the Observer emits an
@@ -40,6 +43,6 @@ public interface ObservableSubscriber<T> extends CompletableSubscriber {
      * @param item the item that has been emitted,
      *             can be null.
      */
-    void onNext(@Nullable T item);
+    public void onNext(@Nullable T item) {}
 
 }

--- a/library/src/main/java/com/anthonycr/bonsai/StreamSubscriber.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamSubscriber.java
@@ -20,24 +20,26 @@
  */
 package com.anthonycr.bonsai;
 
-import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
- * An action to perform when a consumer
- * subscribes to the {@link Observable}.
+ * The interface through which the {@link StreamAction}
+ * communicates to the {@link StreamOnSubscribe}.
  *
- * @param <T> the type the action should emit.
+ * @param <T> the object type that should be emitted.
  */
 @SuppressWarnings("WeakerAccess")
-public interface ObservableAction<T> {
+public interface StreamSubscriber<T> extends CompletableSubscriber {
+
     /**
-     * Should be overridden to send the subscriber
-     * events such as {@link ObservableSubscriber#onNext(Object)}
-     * or {@link ObservableSubscriber#onComplete()}.
+     * Called when the Observer emits an
+     * item. It can be called multiple times.
+     * It cannot be called after onComplete
+     * has been called.
      *
-     * @param subscriber the subscriber that is sent in
-     *                   when the user of the Observable
-     *                   subscribes.
+     * @param item the item that has been emitted,
+     *             can be null.
      */
-    void onSubscribe(@NonNull ObservableSubscriber<T> subscriber);
+    void onNext(@Nullable T item);
+
 }

--- a/library/src/main/java/com/anthonycr/bonsai/Subscription.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Subscription.java
@@ -22,14 +22,14 @@ package com.anthonycr.bonsai;
 
 /**
  * A subscription to an originating
- * Observable that can be unsubscribed.
+ * observable that can be unsubscribed.
  */
 @SuppressWarnings("WeakerAccess")
 public interface Subscription {
 
     /**
      * Calling this method unsubscribes a subscription
-     * from the originating Observable. Once this method
+     * from the originating observable. Once this method
      * is called, no more calls to the OnSubscribe
      * callbacks will be made.
      */

--- a/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
@@ -478,6 +478,24 @@ public class CompletableUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testCompletableThrowsException_onCompleteCalledTwice_noOnSubscribe() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Completable.create(new CompletableAction() {
+            @Override
+            public void onSubscribe(@NonNull CompletableSubscriber subscriber) {
+                try {
+                    subscriber.onComplete();
+                    subscriber.onComplete();
+                } catch (RuntimeException e) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe();
+        assertTrue("Exception should be thrown in subscribe code if onComplete called more than once",
+            errorThrown.get());
+    }
+
+    @Test
     public void testCompletableCreatesLooperIfNotThere() throws Exception {
         final Assertion<Boolean> looperInitiallyNull = new Assertion<>(false);
         final Assertion<Boolean> looperFinallyNotNull = new Assertion<>(false);

--- a/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
@@ -440,6 +440,22 @@ public class CompletableUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testCompletableThrowsException_onStartCalled_noOnSubscribe() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Completable.create(new CompletableAction() {
+            @Override
+            public void onSubscribe(@NonNull CompletableSubscriber subscriber) {
+                try {
+                    subscriber.onStart();
+                } catch (Exception exception) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe();
+        assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+    }
+
+    @Test
     public void testCompletableSubscribesWithoutSubscriber() throws Exception {
         final Assertion<Boolean> isCalledAssertion = new Assertion<>(false);
         Completable.create(new CompletableAction() {

--- a/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
@@ -424,6 +424,22 @@ public class CompletableUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testCompletableThrowsException_onStartCalled() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Completable.create(new CompletableAction() {
+            @Override
+            public void onSubscribe(@NonNull CompletableSubscriber subscriber) {
+                try {
+                    subscriber.onStart();
+                } catch (Exception exception) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe(new CompletableOnSubscribe() {});
+        assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+    }
+
+    @Test
     public void testCompletableSubscribesWithoutSubscriber() throws Exception {
         final Assertion<Boolean> isCalledAssertion = new Assertion<>(false);
         Completable.create(new CompletableAction() {

--- a/library/src/test/java/com/anthonycr/bonsai/OnSubscribeUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/OnSubscribeUnitTest.java
@@ -34,7 +34,7 @@ public class OnSubscribeUnitTest extends BaseUnitTest{
     @Test
     public void testClassType() throws Exception {
         // should be an abstract class
-        Assert.assertTrue(Modifier.isAbstract(ObservableOnSubscribe.class.getModifiers()));
+        Assert.assertTrue(Modifier.isAbstract(StreamOnSubscribe.class.getModifiers()));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class OnSubscribeUnitTest extends BaseUnitTest{
         onSubscribe.onError(new NullPointerException("test exception"));
     }
 
-    private static class TestSubscriberImpl extends ObservableOnSubscribe<String> {
+    private static class TestSubscriberImpl extends StreamOnSubscribe<String> {
 
         public boolean onStart = false;
         public boolean onNext = false;

--- a/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
@@ -343,6 +343,22 @@ public class SingleUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testStreamThrowsException_onStartCalled_noOnSubscribe() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Single.create(new SingleAction<Object>() {
+            @Override
+            public void onSubscribe(@NonNull SingleSubscriber<Object> subscriber) {
+                try {
+                    subscriber.onStart();
+                } catch (Exception exception) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe();
+        assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+    }
+
+    @Test
     public void testSingleUnsubscribe_unsubscribesSuccessfully() throws Exception {
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
         final CountDownLatch latch = new CountDownLatch(1);

--- a/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
@@ -682,6 +682,44 @@ public class SingleUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testCompletableThrowsException_onCompleteCalledTwice_noOnSubscribe() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Single.create(new SingleAction<Object>() {
+            @Override
+            public void onSubscribe(@NonNull SingleSubscriber<Object> subscriber) {
+                try {
+                    subscriber.onComplete();
+                    subscriber.onComplete();
+                } catch (RuntimeException e) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe();
+        assertTrue("Exception should be thrown in subscribe code if onComplete called more than once",
+            errorThrown.get());
+    }
+
+    @Test
+    public void testSingleThrowsException_onItemCalledTwice() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Single.create(new SingleAction<Object>() {
+            @Override
+            public void onSubscribe(@NonNull SingleSubscriber<Object> subscriber) {
+                try {
+                    subscriber.onItem(null);
+                    subscriber.onItem(null);
+                } catch (RuntimeException e) {
+                    errorThrown.set(true);
+                }
+                subscriber.onComplete();
+            }
+        }).subscribe(new SingleOnSubscribe<Object>() {
+        });
+        assertTrue("Exception should be thrown in subscribe code if onItem called after onComplete",
+            errorThrown.get());
+    }
+
+    @Test
     public void testSingleThrowsException_onItemCalledAfterOnComplete() throws Exception {
         final Assertion<Boolean> errorThrown = new Assertion<>(false);
         Single.create(new SingleAction<Object>() {

--- a/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
@@ -327,6 +327,22 @@ public class SingleUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testStreamThrowsException_onStartCalled() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Single.create(new SingleAction<Object>() {
+            @Override
+            public void onSubscribe(@NonNull SingleSubscriber<Object> subscriber) {
+                try {
+                    subscriber.onStart();
+                } catch (Exception exception) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe(new SingleOnSubscribe<Object>() {});
+        assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+    }
+
+    @Test
     public void testSingleUnsubscribe_unsubscribesSuccessfully() throws Exception {
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
         final CountDownLatch latch = new CountDownLatch(1);

--- a/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
@@ -618,6 +618,24 @@ public class StreamUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testStreamThrowsException_onCompleteCalledTwice_noOnSubscribe() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Stream.create(new StreamAction<Object>() {
+            @Override
+            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
+                try {
+                    subscriber.onComplete();
+                    subscriber.onComplete();
+                } catch (RuntimeException e) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe();
+        assertTrue("Exception should be thrown in subscribe code if onComplete called more than once",
+            errorThrown.get());
+    }
+
+    @Test
     public void testStreamThrowsException_onStartCalled() throws Exception {
         final Assertion<Boolean> errorThrown = new Assertion<>(false);
         Stream.create(new StreamAction<Object>() {

--- a/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
@@ -618,6 +618,22 @@ public class StreamUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testStreamThrowsException_onStartCalled() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Stream.create(new StreamAction<Object>() {
+            @Override
+            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
+                try {
+                    subscriber.onStart();
+                } catch (Exception exception) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe(new StreamOnSubscribe<Object>() {});
+        assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+    }
+
+    @Test
     public void testStreamThrowsException_onNextCalledAfterOnComplete() throws Exception {
         final Assertion<Boolean> errorThrown = new Assertion<>(false);
         Stream.create(new StreamAction<Object>() {
@@ -630,10 +646,8 @@ public class StreamUnitTest extends BaseUnitTest {
                     errorThrown.set(true);
                 }
             }
-        }).subscribe(new StreamOnSubscribe<Object>() {
-        });
-        assertTrue("Exception should be thrown in subscribe code if onNext called after onComplete",
-            errorThrown.get());
+        }).subscribe(new StreamOnSubscribe<Object>() {});
+        assertTrue("Exception should be thrown in subscribe code if onNext called after onComplete", errorThrown.get());
     }
 
     @Test

--- a/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
@@ -652,6 +652,22 @@ public class StreamUnitTest extends BaseUnitTest {
     }
 
     @Test
+    public void testStreamThrowsException_onStartCalled_noOnSubscribe() throws Exception {
+        final Assertion<Boolean> errorThrown = new Assertion<>(false);
+        Stream.create(new StreamAction<Object>() {
+            @Override
+            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
+                try {
+                    subscriber.onStart();
+                } catch (Exception exception) {
+                    errorThrown.set(true);
+                }
+            }
+        }).subscribe();
+        assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+    }
+
+    @Test
     public void testStreamThrowsException_onNextCalledAfterOnComplete() throws Exception {
         final Assertion<Boolean> errorThrown = new Assertion<>(false);
         Stream.create(new StreamAction<Object>() {

--- a/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * To work on unit tests, switch the Test Artifact in the Build Variants view.
  */
-public class ObservableUnitTest extends BaseUnitTest {
+public class StreamUnitTest extends BaseUnitTest {
 
     @Test
     public void testMainLooperWorking() throws Exception {
@@ -49,13 +49,13 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableEmissionOrder_singleThread() throws Exception {
+    public void testStreamEmissionOrder_singleThread() throws Exception {
         final int testCount = 7;
 
         final List<String> list = new ArrayList<>(testCount);
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 for (int n = 0; n < testCount; n++) {
                     subscriber.onNext(String.valueOf(n));
                 }
@@ -63,7 +63,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onNext(@Nullable String item) {
                     list.add(item);
@@ -78,7 +78,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableEventEmission_withException() throws Exception {
+    public void testStreamEventEmission_withException() throws Exception {
         final int testCount = 7;
 
         final Assertion<Boolean> errorAssertion = new Assertion<>(false);
@@ -87,9 +87,9 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> startAssertion = new Assertion<>(false);
 
         final List<String> list = new ArrayList<>(testCount);
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 for (int n = 0; n < testCount; n++) {
                     subscriber.onNext(String.valueOf(n));
                 }
@@ -97,7 +97,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
 
                 @Override
                 public void onStart() {
@@ -122,7 +122,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             });
 
         // Even though error has been broadcast,
-        // observable should still complete.
+        // stream should still complete.
         assertTrue(list.size() == testCount);
         for (int n = 0; n < list.size(); n++) {
             assertTrue(String.valueOf(n).equals(list.get(n)));
@@ -137,12 +137,12 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableEventEmission_withoutSubscriber_withException() throws Exception {
+    public void testStreamEventEmission_withoutSubscriber_withException() throws Exception {
         final int testCount = 7;
 
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 for (int n = 0; n < testCount; n++) {
                     subscriber.onNext(String.valueOf(n));
                 }
@@ -156,7 +156,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableEventEmission_withError() throws Exception {
+    public void testStreamEventEmission_withError() throws Exception {
         final int testCount = 7;
 
         final Assertion<Boolean> errorAssertion = new Assertion<>(false);
@@ -165,9 +165,9 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> startAssertion = new Assertion<>(false);
 
         final List<String> list = new ArrayList<>(testCount);
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 for (int n = 0; n < testCount; n++) {
                     subscriber.onNext(String.valueOf(n));
                 }
@@ -180,7 +180,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
 
                 @Override
                 public void onStart() {
@@ -205,7 +205,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             });
 
         // Even though error has been broadcast,
-        // observable should still complete.
+        // stream should still complete.
         assertTrue(list.size() == testCount);
         for (int n = 0; n < list.size(); n++) {
             assertTrue(String.valueOf(n).equals(list.get(n)));
@@ -220,7 +220,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableEventEmission_withoutError() throws Exception {
+    public void testStreamEventEmission_withoutError() throws Exception {
         final int testCount = 7;
 
         final Assertion<Boolean> errorAssertion = new Assertion<>(false);
@@ -229,9 +229,9 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> startAssertion = new Assertion<>(false);
 
         final List<String> list = new ArrayList<>(testCount);
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 for (int n = 0; n < testCount; n++) {
                     subscriber.onNext(String.valueOf(n));
                 }
@@ -239,7 +239,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
 
                 @Override
                 public void onStart() {
@@ -264,7 +264,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             });
 
         // Even though error has been broadcast,
-        // observable should still complete.
+        // stream should still complete.
         assertTrue(list.size() == testCount);
         for (int n = 0; n < list.size(); n++) {
             assertTrue(String.valueOf(n).equals(list.get(n)));
@@ -279,14 +279,14 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableUnsubscribe_unsubscribesSuccessfully() throws Exception {
+    public void testStreamUnsubscribe_unsubscribesSuccessfully() throws Exception {
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
         final CountDownLatch latch = new CountDownLatch(1);
         final Assertion<Boolean> assertion = new Assertion<>(false);
-        Subscription stringSubscription = Observable.create(new ObservableAction<String>() {
+        Subscription stringSubscription = Stream.create(new StreamAction<String>() {
 
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 try {
                     subscribeLatch.await();
                 } catch (InterruptedException e) {
@@ -297,7 +297,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.io())
             .observeOn(Schedulers.io())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onNext(@Nullable String item) {
                     assertion.set(true);
@@ -312,7 +312,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableThread_onStart_isCorrect() throws Exception {
+    public void testStreamThread_onStart_isCorrect() throws Exception {
         final CountDownLatch observeLatch = new CountDownLatch(1);
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
 
@@ -322,17 +322,17 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> onStartAssertion = new Assertion<>(false);
         final Assertion<Boolean> onErrorAssertion = new Assertion<>(false);
 
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
 
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 subscribeThreadAssertion.set(Thread.currentThread().toString());
                 subscribeLatch.countDown();
                 subscriber.onComplete();
             }
         }).subscribeOn(Schedulers.worker())
             .observeOn(Schedulers.io())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onNext(@Nullable String item) {
 
@@ -370,7 +370,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableThread_onNext_isCorrect() throws Exception {
+    public void testStreamThread_onNext_isCorrect() throws Exception {
         final CountDownLatch observeLatch = new CountDownLatch(1);
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
 
@@ -380,10 +380,10 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> onNextAssertion = new Assertion<>(false);
         final Assertion<Boolean> onErrorAssertion = new Assertion<>(false);
 
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
 
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 subscribeThreadAssertion.set(Thread.currentThread().toString());
                 subscribeLatch.countDown();
                 subscriber.onNext(null);
@@ -391,7 +391,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.worker())
             .observeOn(Schedulers.io())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onError(@NonNull Throwable throwable) {
                     onErrorAssertion.set(true);
@@ -424,7 +424,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableThread_onComplete_isCorrect() throws Exception {
+    public void testStreamThread_onComplete_isCorrect() throws Exception {
         final CountDownLatch observeLatch = new CountDownLatch(1);
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
 
@@ -434,17 +434,17 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> onCompleteAssertion = new Assertion<>(false);
         final Assertion<Boolean> onErrorAssertion = new Assertion<>(false);
 
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
 
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 subscribeThreadAssertion.set(Thread.currentThread().toString());
                 subscribeLatch.countDown();
                 subscriber.onComplete();
             }
         }).subscribeOn(Schedulers.worker())
             .observeOn(Schedulers.io())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onError(@NonNull Throwable throwable) {
                     onErrorAssertion.set(true);
@@ -477,7 +477,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableThread_onError_isCorrect() throws Exception {
+    public void testStreamThread_onError_isCorrect() throws Exception {
         final CountDownLatch observeLatch = new CountDownLatch(1);
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
 
@@ -487,17 +487,17 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> onCompleteAssertion = new Assertion<>(false);
         final Assertion<Boolean> onErrorAssertion = new Assertion<>(false);
 
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
 
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 subscribeThreadAssertion.set(Thread.currentThread().toString());
                 subscribeLatch.countDown();
                 subscriber.onError(new RuntimeException("There was a problem"));
             }
         }).subscribeOn(Schedulers.worker())
             .observeOn(Schedulers.io())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onError(@NonNull Throwable throwable) {
                     onErrorAssertion.set(true);
@@ -530,7 +530,7 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableThread_ThrownException_isCorrect() throws Exception {
+    public void testStreamThread_ThrownException_isCorrect() throws Exception {
         final CountDownLatch observeLatch = new CountDownLatch(1);
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
 
@@ -540,17 +540,17 @@ public class ObservableUnitTest extends BaseUnitTest {
         final Assertion<Boolean> onCompleteAssertion = new Assertion<>(false);
         final Assertion<Boolean> onErrorAssertion = new Assertion<>(false);
 
-        Observable.create(new ObservableAction<String>() {
+        Stream.create(new StreamAction<String>() {
 
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 subscribeThreadAssertion.set(Thread.currentThread().toString());
                 subscribeLatch.countDown();
                 throw new RuntimeException("There was a problem");
             }
         }).subscribeOn(Schedulers.worker())
             .observeOn(Schedulers.io())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onError(@NonNull Throwable throwable) {
                     onErrorAssertion.set(true);
@@ -583,11 +583,11 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableSubscribesWithoutSubscriber() throws Exception {
+    public void testStreamSubscribesWithoutSubscriber() throws Exception {
         final Assertion<Boolean> isCalledAssertion = new Assertion<>(false);
-        Observable.create(new ObservableAction<Object>() {
+        Stream.create(new StreamAction<Object>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<Object> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
                 subscriber.onNext(null);
                 subscriber.onComplete();
                 isCalledAssertion.set(true);
@@ -599,11 +599,11 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableThrowsException_onCompleteCalledTwice() throws Exception {
+    public void testStreamThrowsException_onCompleteCalledTwice() throws Exception {
         final Assertion<Boolean> errorThrown = new Assertion<>(false);
-        Observable.create(new ObservableAction<Object>() {
+        Stream.create(new StreamAction<Object>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<Object> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
                 try {
                     subscriber.onComplete();
                     subscriber.onComplete();
@@ -611,18 +611,18 @@ public class ObservableUnitTest extends BaseUnitTest {
                     errorThrown.set(true);
                 }
             }
-        }).subscribe(new ObservableOnSubscribe<Object>() {
+        }).subscribe(new StreamOnSubscribe<Object>() {
         });
         assertTrue("Exception should be thrown in subscribe code if onComplete called more than once",
             errorThrown.get());
     }
 
     @Test
-    public void testObservableThrowsException_onNextCalledAfterOnComplete() throws Exception {
+    public void testStreamThrowsException_onNextCalledAfterOnComplete() throws Exception {
         final Assertion<Boolean> errorThrown = new Assertion<>(false);
-        Observable.create(new ObservableAction<Object>() {
+        Stream.create(new StreamAction<Object>() {
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<Object> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
                 try {
                     subscriber.onComplete();
                     subscriber.onNext(null);
@@ -630,14 +630,14 @@ public class ObservableUnitTest extends BaseUnitTest {
                     errorThrown.set(true);
                 }
             }
-        }).subscribe(new ObservableOnSubscribe<Object>() {
+        }).subscribe(new StreamOnSubscribe<Object>() {
         });
         assertTrue("Exception should be thrown in subscribe code if onNext called after onComplete",
             errorThrown.get());
     }
 
     @Test
-    public void testObservableCreatesLooperIfNotThere() throws Exception {
+    public void testStreamCreatesLooperIfNotThere() throws Exception {
         final Assertion<Boolean> looperInitiallyNull = new Assertion<>(false);
         final Assertion<Boolean> looperFinallyNotNull = new Assertion<>(false);
         final CountDownLatch latch = new CountDownLatch(1);
@@ -646,9 +646,9 @@ public class ObservableUnitTest extends BaseUnitTest {
             public void run() {
                 // No looper associated with this thread yet
                 looperInitiallyNull.set(Looper.myLooper() == null);
-                Observable.create(new ObservableAction<Object>() {
+                Stream.create(new StreamAction<Object>() {
                     @Override
-                    public void onSubscribe(@NonNull ObservableSubscriber<Object> subscriber) {
+                    public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
                         looperFinallyNotNull.set(Looper.myLooper() != null);
                     }
                 }).subscribe();
@@ -657,20 +657,20 @@ public class ObservableUnitTest extends BaseUnitTest {
         });
         latch.await();
         assertTrue("Looper should initially be null", looperInitiallyNull.get());
-        assertTrue("Looper should be initialized by observable class", looperFinallyNotNull.get());
+        assertTrue("Looper should be initialized by stream class", looperFinallyNotNull.get());
     }
 
     @Test
-    public void testObservableSubscriberIsUnsubscribed() throws Exception {
+    public void testStreamSubscriberIsUnsubscribed() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch onNextLatch = new CountDownLatch(1);
         final CountDownLatch onFinalLatch = new CountDownLatch(1);
         final Assertion<Boolean> unsubscribed = new Assertion<>(false);
         final List<String> list = new ArrayList<>();
-        Subscription subscription = Observable.create(new ObservableAction<String>() {
+        Subscription subscription = Stream.create(new StreamAction<String>() {
 
             @Override
-            public void onSubscribe(@NonNull ObservableSubscriber<String> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 if (!subscriber.isUnsubscribed()) {
                     subscriber.onNext("test 1");
                 }
@@ -688,7 +688,7 @@ public class ObservableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.newSingleThreadedScheduler())
             .observeOn(Schedulers.newSingleThreadedScheduler())
-            .subscribe(new ObservableOnSubscribe<String>() {
+            .subscribe(new StreamOnSubscribe<String>() {
                 @Override
                 public void onNext(@Nullable String item) {
                     list.add(item);
@@ -707,10 +707,10 @@ public class ObservableUnitTest extends BaseUnitTest {
     }
 
     @Test
-    public void testObservableEmpty_emitsNothingImmediately() throws Exception {
+    public void testStreamEmpty_emitsNothingImmediately() throws Exception {
         final Assertion<Boolean> onNextAssertion = new Assertion<>(false);
         final Assertion<Boolean> onCompleteAssertion = new Assertion<>(false);
-        Observable.empty().subscribe(new ObservableOnSubscribe<Object>() {
+        Stream.empty().subscribe(new StreamOnSubscribe<Object>() {
 
             @Override
             public void onNext(@Nullable Object item) {

--- a/sample/src/main/java/com/anthonycr/sample/DataModel.java
+++ b/sample/src/main/java/com/anthonycr/sample/DataModel.java
@@ -49,7 +49,7 @@ public final class DataModel {
      * be emitted.
      */
     @NonNull
-    public static Single<List<Contact>> allContactsObservable() {
+    public static Single<List<Contact>> allContactsSingle() {
         return Single.create(new SingleAction<List<Contact>>() {
             @Override
             public void onSubscribe(@NonNull SingleSubscriber<List<Contact>> subscriber) {
@@ -87,7 +87,7 @@ public final class DataModel {
      * which will notify you when the observable finishes completing.
      */
     @NonNull
-    public static Completable addContactObservable(@NonNull final Contact contact) {
+    public static Completable addContactCompletable(@NonNull final Contact contact) {
         return Completable.create(new CompletableAction() {
             @Override
             public void onSubscribe(@NonNull CompletableSubscriber subscriber) {
@@ -106,7 +106,7 @@ public final class DataModel {
      * which will notify you when the observable finishes completing.
      */
     @NonNull
-    public static Completable updateContactObservable(@NonNull final Contact contact) {
+    public static Completable updateContactCompletable(@NonNull final Contact contact) {
         return Completable.create(new CompletableAction() {
             @Override
             public void onSubscribe(@NonNull CompletableSubscriber subscriber) {
@@ -125,7 +125,7 @@ public final class DataModel {
      * which will notify you when the observable finishes completing.
      */
     @NonNull
-    public static Completable deleteContactObservable(@NonNull final Contact contact) {
+    public static Completable deleteContactCompletable(@NonNull final Contact contact) {
         return Completable.create(new CompletableAction() {
             @Override
             public void onSubscribe(@NonNull CompletableSubscriber subscriber) {

--- a/sample/src/main/java/com/anthonycr/sample/MainActivity.java
+++ b/sample/src/main/java/com/anthonycr/sample/MainActivity.java
@@ -92,7 +92,7 @@ public class MainActivity extends AppCompatActivity {
         // Loads all the initial data from the database on a separate thread
         // then notifies the main thread after the data is loaded. Then we
         // add all the items we received to the adapter and they get displayed.
-        getAllContactsSubscription = DataModel.allContactsObservable()
+        getAllContactsSubscription = DataModel.allContactsSingle()
             .subscribeOn(Schedulers.io())
             .observeOn(Schedulers.main())
             .subscribe(new SingleOnSubscribe<List<Contact>>() {
@@ -133,7 +133,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
 
-        // Here we unsubscribe from the Observables
+        // Here we unsubscribe from the observables
         // that all these Subscriptions were subscribed
         // to. The purpose for this is to prevent a
         // memory leak. In reality, these database operations
@@ -173,7 +173,7 @@ public class MainActivity extends AppCompatActivity {
                     // the database on the background thread, then receive
                     // notification when it has finished inserting into the
                     // database.
-                    addContactSubscription = DataModel.addContactObservable(newContact)
+                    addContactSubscription = DataModel.addContactCompletable(newContact)
                         .subscribeOn(Schedulers.io())
                         .observeOn(Schedulers.main())
                         .subscribe(new CompletableOnSubscribe() {
@@ -211,7 +211,7 @@ public class MainActivity extends AppCompatActivity {
                 // with the new values for the contact. The update is
                 // done on a background thread, and then calls back
                 // onto the main thread, where we update the adapter.
-                editContactSubscription = DataModel.updateContactObservable(contact)
+                editContactSubscription = DataModel.updateContactCompletable(contact)
                     .subscribeOn(Schedulers.io())
                     .observeOn(Schedulers.main())
                     .subscribe(new CompletableOnSubscribe() {
@@ -229,7 +229,7 @@ public class MainActivity extends AppCompatActivity {
                 // delete the item from the database. When the operation
                 // completes, we call back to the main thread to update
                 // the UI and remove the item from the list.
-                deleteContactSubscription = DataModel.deleteContactObservable(contact)
+                deleteContactSubscription = DataModel.deleteContactCompletable(contact)
                     .subscribeOn(Schedulers.io())
                     .observeOn(Schedulers.main())
                     .subscribe(new CompletableOnSubscribe() {


### PR DESCRIPTION
- Completing addition of Completable and Single.
- Renamed `Observable` to `Stream` - This is in part because `Completable` and `Single` are observables so now there are 3 observable classes supported by bonsai.
- Throw an exception if someone calls `onStart` since this is handled internally be bonsai observables.
- Fixed a bug where exceptions that should have been thrown weren't thrown if the consumer of the observable didn't supply an `OnSubscribe`.