### PR TITLE
Common observable logic

### DIFF
--- a/library/src/main/java/com/anthonycr/bonsai/Action.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Action.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Anthony C. Restaino
+ * Copyright (C) 2017 Anthony C. Restaino
  * <p/>
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,11 +20,21 @@
  */
 package com.anthonycr.bonsai;
 
-/**
- * An action to perform when a consumer
- * subscribes to the {@link Completable}.
- */
-@SuppressWarnings("WeakerAccess")
-public interface CompletableAction extends Action<CompletableSubscriber> {
+import android.support.annotation.NonNull;
 
+/**
+ * Created by anthonycr on 2/20/17.
+ */
+interface Action<T> {
+
+    /**
+     * Should be overridden to send the subscriber
+     * events such as {@link SingleSubscriber#onItem(Object)}
+     * or {@link SingleSubscriber#onComplete()}.
+     *
+     * @param subscriber the subscriber that is sent in
+     *                   when the user of the observable
+     *                   subscribes.
+     */
+    void onSubscribe(@NonNull T subscriber);
 }

--- a/library/src/main/java/com/anthonycr/bonsai/Completable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Completable.java
@@ -72,6 +72,32 @@ public class Completable extends Observable<CompletableAction, CompletableOnSubs
         });
     }
 
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe work should run on.
+     *
+     * @param subscribeScheduler the {@link Scheduler} to run the work on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Completable subscribeOn(@NonNull Scheduler subscribeScheduler) {
+        setActionScheduler(subscribeScheduler);
+        return this;
+    }
+
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe should observe the work on.
+     *
+     * @param observerScheduler the {@link Scheduler} to run to callback on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Completable observeOn(@NonNull Scheduler observerScheduler) {
+        setObserverScheduler(observerScheduler);
+        return this;
+    }
+
     @NonNull
     @Override
     protected CompletableSubscriber createSubscriberWrapper(@Nullable CompletableOnSubscribe onSubscribe,

--- a/library/src/main/java/com/anthonycr/bonsai/Completable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Completable.java
@@ -20,7 +20,6 @@
  */
 package com.anthonycr.bonsai;
 
-import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -37,21 +36,10 @@ import android.support.annotation.Nullable;
  * errors that occur.
  */
 @SuppressWarnings("WeakerAccess")
-public class Completable {
-
-    @NonNull private final CompletableAction action;
-    @NonNull private final Scheduler defaultThread;
-    @Nullable private Scheduler subscriberThread;
-    @Nullable private Scheduler observerThread;
+public class Completable extends Observable<CompletableAction, CompletableOnSubscribe, CompletableSubscriber> {
 
     private Completable(@NonNull CompletableAction action) {
-        this.action = action;
-        if (Looper.myLooper() == null) {
-            Looper.prepare();
-        }
-        Looper looper = Looper.myLooper();
-        Preconditions.checkNonNull(looper);
-        this.defaultThread = new ThreadScheduler(looper);
+        super(action);
     }
 
     /**
@@ -84,82 +72,12 @@ public class Completable {
         });
     }
 
-    /**
-     * Tells the Completable what Scheduler that the onSubscribe
-     * work should run on.
-     *
-     * @param subscribeScheduler the Scheduler to run the work on.
-     * @return returns this so that calls can be conveniently chained.
-     */
     @NonNull
-    public Completable subscribeOn(@NonNull Scheduler subscribeScheduler) {
-        subscriberThread = subscribeScheduler;
-        return this;
-    }
-
-    /**
-     * Tells the Completable what Scheduler the onSubscribe
-     * should observe the work on.
-     *
-     * @param observerScheduler the Scheduler to run to callback on.
-     * @return returns this so that calls can be conveniently chained.
-     */
-    @NonNull
-    public Completable observeOn(@NonNull Scheduler observerScheduler) {
-        observerThread = observerScheduler;
-        return this;
-    }
-
-    /**
-     * Subscribes immediately to the Completable and
-     * ignores all onComplete calls.
-     */
-    public void subscribe() {
-        startSubscription(null);
-    }
-
-    /**
-     * Immediately subscribes to the Completable and starts
-     * sending events from the Completable to the
-     * {@link StreamOnSubscribe}.
-     *
-     * @param onSubscribe the class that wishes to receive onComplete
-     *                    callbacks from the Completable.
-     */
-    @NonNull
-    public Subscription subscribe(@NonNull CompletableOnSubscribe onSubscribe) {
-        Preconditions.checkNonNull(onSubscribe);
-
-        return startSubscription(onSubscribe);
-    }
-
-    @NonNull
-    private Subscription startSubscription(@Nullable CompletableOnSubscribe onSubscribe) {
-        final CompletableSubscriberWrapper<CompletableOnSubscribe> subscriber =
-            new CompletableSubscriberWrapper<>(onSubscribe, observerThread, defaultThread);
-
-        subscriber.onStart();
-
-        executeOnSubscriberThread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    action.onSubscribe(subscriber);
-                } catch (Exception exception) {
-                    subscriber.onError(exception);
-                }
-            }
-        });
-
-        return subscriber;
-    }
-
-    void executeOnSubscriberThread(@NonNull Runnable runnable) {
-        if (subscriberThread != null) {
-            subscriberThread.execute(runnable);
-        } else {
-            defaultThread.execute(runnable);
-        }
+    @Override
+    protected CompletableSubscriber createSubscriberWrapper(@Nullable CompletableOnSubscribe onSubscribe,
+                                                            @Nullable Scheduler observerThread,
+                                                            @NonNull Scheduler defaultThread) {
+        return new CompletableSubscriberWrapper<>(onSubscribe, observerThread, defaultThread);
     }
 
 }

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableAction.java
@@ -25,6 +25,6 @@ package com.anthonycr.bonsai;
  * subscribes to the {@link Completable}.
  */
 @SuppressWarnings("WeakerAccess")
-public interface CompletableAction extends Action<CompletableSubscriber> {
+public interface CompletableAction extends ObservableAction<CompletableSubscriber> {
 
 }

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriber.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriber.java
@@ -20,38 +20,12 @@
  */
 package com.anthonycr.bonsai;
 
-import android.support.annotation.NonNull;
-
 /**
  * The interface through which the {@link CompletableAction}
  * communicates to the {@link CompletableOnSubscribe}.
  */
 @SuppressWarnings("WeakerAccess")
-public interface CompletableSubscriber extends Subscription {
-
-    /**
-     * Called immediately upon subscribing
-     * and before the observable begins
-     * emitting items. This should not be
-     * called by the creator of the observable
-     * and is rather called internally by the
-     * observable class itself.
-     */
-    void onStart();
-
-    /**
-     * Called when the observable
-     * runs into an error that will
-     * cause it to abort and not finish.
-     * Receiving this callback means that
-     * the observable is dead and no
-     * {@link #onComplete()}
-     * callbacks will be called.
-     *
-     * @param throwable an optional throwable that could
-     *                  be sent.
-     */
-    void onError(@NonNull Throwable throwable);
+public interface CompletableSubscriber extends ObservableSubscriber {
 
     /**
      * This method is called when the observer is

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriber.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriber.java
@@ -61,16 +61,4 @@ public interface CompletableSubscriber extends Subscription {
      * has been called.
      */
     void onComplete();
-
-    /**
-     * This method tells the caller whether or not
-     * the subscriber to this observable has unsubscribed
-     * or not. Useful for long running or never ending
-     * operations that would otherwise needlessly use
-     * resources.
-     *
-     * @return true if the the Subscriber has unsubscribed,
-     * false otherwise.
-     */
-    boolean isUnsubscribed();
 }

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriberWrapper.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriberWrapper.java
@@ -29,40 +29,20 @@ import android.support.annotation.Nullable;
  * the callbacks on the correct threads, and throws the
  * appropriate errors when certain rules are violated.
  */
-class CompletableSubscriberWrapper<T extends CompletableOnSubscribe> implements CompletableSubscriber {
+@SuppressWarnings("WeakerAccess")
+class CompletableSubscriberWrapper<T extends CompletableOnSubscribe> extends ObservableSubscriberWrapper<T> implements CompletableSubscriber {
 
-    private volatile boolean onStartExecuted = false;
-    volatile boolean onCompleteExecuted = false;
-    volatile boolean onErrorExecuted = false;
-
-    @Nullable private final Scheduler observerThread;
-    @NonNull private final Scheduler defaultThread;
-    @Nullable protected volatile T onSubscribe;
+    protected volatile boolean onCompleteExecuted;
 
     CompletableSubscriberWrapper(@Nullable T onSubscribe,
                                  @Nullable Scheduler observerThread,
                                  @NonNull Scheduler defaultThread) {
-        this.onSubscribe = onSubscribe;
-        this.observerThread = observerThread;
-        this.defaultThread = defaultThread;
-    }
-
-    void executeOnObserverThread(@NonNull Runnable runnable) {
-        if (observerThread != null) {
-            observerThread.execute(runnable);
-        } else {
-            defaultThread.execute(runnable);
-        }
-    }
-
-    @Override
-    public void unsubscribe() {
-        onSubscribe = null;
+        super(onSubscribe, observerThread, defaultThread);
     }
 
     @Override
     public void onComplete() {
-        CompletableOnSubscribe onSubscribe = this.onSubscribe;
+        T onSubscribe = this.onSubscribe;
 
         if (onCompleteExecuted) {
             throw new RuntimeException("onComplete called more than once");
@@ -73,36 +53,5 @@ class CompletableSubscriberWrapper<T extends CompletableOnSubscribe> implements 
         onCompleteExecuted = true;
 
         unsubscribe();
-    }
-
-    @Override
-    public void onStart() {
-        CompletableOnSubscribe onSubscribe = this.onSubscribe;
-
-        if (onStartExecuted) {
-            throw new RuntimeException("onStart is called internally, do not call it yourself");
-        } else if (onSubscribe != null) {
-            executeOnObserverThread(new OnStartRunnable(onSubscribe));
-        }
-
-        onStartExecuted = true;
-    }
-
-    @Override
-    public void onError(@NonNull final Throwable throwable) {
-        CompletableOnSubscribe onSubscribe = this.onSubscribe;
-
-        if (onSubscribe != null) {
-            executeOnObserverThread(new OnErrorRunnable(onSubscribe, throwable));
-        }
-
-        onErrorExecuted = true;
-
-        unsubscribe();
-    }
-
-    @Override
-    public boolean isUnsubscribed() {
-        return onSubscribe == null;
     }
 }

--- a/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriberWrapper.java
+++ b/library/src/main/java/com/anthonycr/bonsai/CompletableSubscriberWrapper.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2017 Anthony C. Restaino
+ * <p/>
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.anthonycr.bonsai;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/anthonycr/bonsai/Observable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Observable.java
@@ -25,27 +25,27 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
- * @param <ActionType>      The {@link Action} that will be provided
- *                          to the {@link OnSubscribeType} when the
- *                          consumer subscribes.
- * @param <OnSubscribeType> The {@link CompletableOnSubscribe} or type that
- *                          extends it that will be supplied when the consumer
- *                          subscribes.
- * @param <SubscriberType>  The {@link CompletableSubscriber} or type that
- *                          extends it that will be supplied to the {@link Action}
- *                          when the consumer subscribes.
+ * @param <ActionT>      The {@link Action} that will be provided
+ *                       to the {@link OnSubscribeT} when the
+ *                       consumer subscribes.
+ * @param <OnSubscribeT> The {@link CompletableOnSubscribe} or type that
+ *                       extends it that will be supplied when the consumer
+ *                       subscribes.
+ * @param <SubscriberT>  The {@link CompletableSubscriber} or type that
+ *                       extends it that will be supplied to the {@link Action}
+ *                       when the consumer subscribes.
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class Observable<ActionType extends Action<SubscriberType>,
-    OnSubscribeType extends CompletableOnSubscribe,
-    SubscriberType extends CompletableSubscriber> {
+public abstract class Observable<ActionT extends Action<SubscriberT>,
+    OnSubscribeT extends CompletableOnSubscribe,
+    SubscriberT extends CompletableSubscriber> {
 
-    @NonNull private final ActionType action;
+    @NonNull private final ActionT action;
     @Nullable private Scheduler subscriberThread;
     @Nullable private Scheduler observerThread;
     @NonNull private final Scheduler defaultThread;
 
-    protected Observable(@NonNull ActionType action) {
+    protected Observable(@NonNull ActionT action) {
         this.action = action;
         this.defaultThread = getCurrentScheduler();
     }
@@ -66,12 +66,9 @@ public abstract class Observable<ActionType extends Action<SubscriberType>,
      * the onSubscribe work should run on.
      *
      * @param subscribeScheduler the {@link Scheduler} to run the work on.
-     * @return returns itself so that calls can be conveniently chained.
      */
-    @NonNull
-    public final Observable<ActionType, OnSubscribeType, SubscriberType> subscribeOn(@NonNull Scheduler subscribeScheduler) {
+    protected final void setActionScheduler(@NonNull Scheduler subscribeScheduler) {
         subscriberThread = subscribeScheduler;
-        return this;
     }
 
     /**
@@ -79,12 +76,9 @@ public abstract class Observable<ActionType extends Action<SubscriberType>,
      * the onSubscribe should observe the work on.
      *
      * @param observerScheduler the {@link Scheduler} to run to callback on.
-     * @return returns itself so that calls can be conveniently chained.
      */
-    @NonNull
-    public final Observable<ActionType, OnSubscribeType, SubscriberType> observeOn(@NonNull Scheduler observerScheduler) {
+    protected final void setObserverScheduler(@NonNull Scheduler observerScheduler) {
         observerThread = observerScheduler;
-        return this;
     }
 
     /**
@@ -101,41 +95,41 @@ public abstract class Observable<ActionType extends Action<SubscriberType>,
     /**
      * Immediately subscribes to the {@link Observable} and
      * starts sending events from the {@link Observable} to the
-     * {@link OnSubscribeType}.
+     * {@link OnSubscribeT}.
      *
      * @param onSubscribe the class that wishes to receive onComplete
      *                    callbacks from the Completable.
      * @return a work subscription that can be cancelled.
      */
     @NonNull
-    public final Subscription subscribe(@NonNull OnSubscribeType onSubscribe) {
+    public final Subscription subscribe(@NonNull OnSubscribeT onSubscribe) {
         Preconditions.checkNonNull(onSubscribe);
 
         return startSubscription(onSubscribe);
     }
 
     /**
-     * Creates a {@link SubscriberType} that
-     * wraps the {@link OnSubscribeType} in order
+     * Creates a {@link SubscriberT} that
+     * wraps the {@link OnSubscribeT} in order
      * to properly execute method calls on the
      * appropriate observer thread.
      *
-     * @param onSubscribe    the {@link OnSubscribeType} supplied when
+     * @param onSubscribe    the {@link OnSubscribeT} supplied when
      *                       the consumer subscribed.
-     * @param observerThread the thread that the {@link OnSubscribeType}
+     * @param observerThread the thread that the {@link OnSubscribeT}
      *                       should be notified on, may be null.
-     * @param defaultThread  the thread to notify the {@link OnSubscribeType}
+     * @param defaultThread  the thread to notify the {@link OnSubscribeT}
      *                       on if the provided observer is null.
-     * @return a valid {@link SubscriberType} that wraps the {@link OnSubscribeType}.
+     * @return a valid {@link SubscriberT} that wraps the {@link OnSubscribeT}.
      */
     @NonNull
-    protected abstract SubscriberType createSubscriberWrapper(@Nullable OnSubscribeType onSubscribe,
-                                                              @Nullable Scheduler observerThread,
-                                                              @NonNull Scheduler defaultThread);
+    protected abstract SubscriberT createSubscriberWrapper(@Nullable OnSubscribeT onSubscribe,
+                                                           @Nullable Scheduler observerThread,
+                                                           @NonNull Scheduler defaultThread);
 
     @NonNull
-    private Subscription startSubscription(@Nullable OnSubscribeType onSubscribe) {
-        final SubscriberType subscriber = createSubscriberWrapper(onSubscribe, observerThread, defaultThread);
+    private Subscription startSubscription(@Nullable OnSubscribeT onSubscribe) {
+        final SubscriberT subscriber = createSubscriberWrapper(onSubscribe, observerThread, defaultThread);
 
         subscriber.onStart();
 

--- a/library/src/main/java/com/anthonycr/bonsai/Observable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Observable.java
@@ -25,20 +25,20 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
- * @param <ActionT>      The {@link Action} that will be provided
+ * @param <ActionT>      The {@link ObservableAction} that will be provided
  *                       to the {@link OnSubscribeT} when the
  *                       consumer subscribes.
- * @param <OnSubscribeT> The {@link CompletableOnSubscribe} or type that
+ * @param <OnSubscribeT> The {@link ObservableOnSubscribe} or type that
  *                       extends it that will be supplied when the consumer
  *                       subscribes.
- * @param <SubscriberT>  The {@link CompletableSubscriber} or type that
- *                       extends it that will be supplied to the {@link Action}
+ * @param <SubscriberT>  The {@link ObservableSubscriber} or type that
+ *                       extends it that will be supplied to the {@link ObservableAction}
  *                       when the consumer subscribes.
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class Observable<ActionT extends Action<SubscriberT>,
-    OnSubscribeT extends CompletableOnSubscribe,
-    SubscriberT extends CompletableSubscriber> {
+public abstract class Observable<ActionT extends ObservableAction<SubscriberT>,
+    OnSubscribeT extends ObservableOnSubscribe,
+    SubscriberT extends ObservableSubscriber> {
 
     @NonNull private final ActionT action;
     @Nullable private Scheduler subscriberThread;
@@ -83,7 +83,7 @@ public abstract class Observable<ActionT extends Action<SubscriberT>,
 
     /**
      * Subscribes immediately to the {@link Observable} and
-     * ignores all onComplete calls.
+     * ignores all calls to the subscriber.
      *
      * @return a work subscription that can be cancelled.
      */
@@ -97,8 +97,8 @@ public abstract class Observable<ActionT extends Action<SubscriberT>,
      * starts sending events from the {@link Observable} to the
      * {@link OnSubscribeT}.
      *
-     * @param onSubscribe the class that wishes to receive onComplete
-     *                    callbacks from the Completable.
+     * @param onSubscribe the class that wishes to receive
+     *                    callbacks from the observable.
      * @return a work subscription that can be cancelled.
      */
     @NonNull

--- a/library/src/main/java/com/anthonycr/bonsai/Observable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Observable.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2017 Anthony C. Restaino
+ * <p/>
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.anthonycr.bonsai;
+
+import android.os.Looper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * @param <ActionType>      The {@link Action} that will be provided
+ *                          to the {@link OnSubscribeType} when the
+ *                          consumer subscribes.
+ * @param <OnSubscribeType>
+ * @param <SubscriberType>
+ */
+@SuppressWarnings("WeakerAccess")
+public abstract class Observable<ActionType extends Action<SubscriberType>,
+    OnSubscribeType extends CompletableOnSubscribe,
+    SubscriberType extends CompletableSubscriber> {
+
+    @NonNull private final ActionType action;
+    @Nullable private Scheduler subscriberThread;
+    @Nullable private Scheduler observerThread;
+    @NonNull private final Scheduler defaultThread;
+
+    protected Observable(@NonNull ActionType action) {
+        this.action = action;
+        this.defaultThread = getCurrentScheduler();
+    }
+
+    @NonNull
+    private Scheduler getCurrentScheduler() {
+        if (Looper.myLooper() == null) {
+            Looper.prepare();
+        }
+        Looper looper = Looper.myLooper();
+        Preconditions.checkNonNull(looper);
+
+        return new ThreadScheduler(looper);
+    }
+
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe work should run on.
+     *
+     * @param subscribeScheduler the {@link Scheduler} to run the work on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Observable<ActionType, OnSubscribeType, SubscriberType> subscribeOn(@NonNull Scheduler subscribeScheduler) {
+        subscriberThread = subscribeScheduler;
+        return this;
+    }
+
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe should observe the work on.
+     *
+     * @param observerScheduler the {@link Scheduler} to run to callback on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Observable<ActionType, OnSubscribeType, SubscriberType> observeOn(@NonNull Scheduler observerScheduler) {
+        observerThread = observerScheduler;
+        return this;
+    }
+
+    /**
+     * Subscribes immediately to the {@link Observable} and
+     * ignores all onComplete calls.
+     *
+     * @return a work subscription that can be cancelled.
+     */
+    @NonNull
+    public final Subscription subscribe() {
+        return startSubscription(null);
+    }
+
+    /**
+     * Immediately subscribes to the {@link Observable} and
+     * starts sending events from the {@link Observable} to the
+     * {@link OnSubscribeType}.
+     *
+     * @param onSubscribe the class that wishes to receive onComplete
+     *                    callbacks from the Completable.
+     * @return a work subscription that can be cancelled.
+     */
+    @NonNull
+    public final Subscription subscribe(@NonNull OnSubscribeType onSubscribe) {
+        Preconditions.checkNonNull(onSubscribe);
+
+        return startSubscription(onSubscribe);
+    }
+
+    /**
+     * Creates a subscriber
+     *
+     * @param onSubscribe
+     * @param observerThread
+     * @param defaultThread
+     * @return
+     */
+    @NonNull
+    protected abstract SubscriberType createSubscriberWrapper(@Nullable OnSubscribeType onSubscribe,
+                                                              @Nullable Scheduler observerThread,
+                                                              @NonNull Scheduler defaultThread);
+
+    @NonNull
+    private Subscription startSubscription(@Nullable OnSubscribeType onSubscribe) {
+        final SubscriberType subscriber = createSubscriberWrapper(onSubscribe, observerThread, defaultThread);
+
+        subscriber.onStart();
+
+        executeOnSubscriberThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    action.onSubscribe(subscriber);
+                } catch (Exception exception) {
+                    subscriber.onError(exception);
+                }
+            }
+        });
+
+        return subscriber;
+    }
+
+    private void executeOnSubscriberThread(@NonNull Runnable runnable) {
+        if (subscriberThread != null) {
+            subscriberThread.execute(runnable);
+        } else {
+            defaultThread.execute(runnable);
+        }
+    }
+
+}

--- a/library/src/main/java/com/anthonycr/bonsai/Observable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Observable.java
@@ -28,8 +28,12 @@ import android.support.annotation.Nullable;
  * @param <ActionType>      The {@link Action} that will be provided
  *                          to the {@link OnSubscribeType} when the
  *                          consumer subscribes.
- * @param <OnSubscribeType>
- * @param <SubscriberType>
+ * @param <OnSubscribeType> The {@link CompletableOnSubscribe} or type that
+ *                          extends it that will be supplied when the consumer
+ *                          subscribes.
+ * @param <SubscriberType>  The {@link CompletableSubscriber} or type that
+ *                          extends it that will be supplied to the {@link Action}
+ *                          when the consumer subscribes.
  */
 @SuppressWarnings("WeakerAccess")
 public abstract class Observable<ActionType extends Action<SubscriberType>,
@@ -111,12 +115,18 @@ public abstract class Observable<ActionType extends Action<SubscriberType>,
     }
 
     /**
-     * Creates a subscriber
+     * Creates a {@link SubscriberType} that
+     * wraps the {@link OnSubscribeType} in order
+     * to properly execute method calls on the
+     * appropriate observer thread.
      *
-     * @param onSubscribe
-     * @param observerThread
-     * @param defaultThread
-     * @return
+     * @param onSubscribe    the {@link OnSubscribeType} supplied when
+     *                       the consumer subscribed.
+     * @param observerThread the thread that the {@link OnSubscribeType}
+     *                       should be notified on, may be null.
+     * @param defaultThread  the thread to notify the {@link OnSubscribeType}
+     *                       on if the provided observer is null.
+     * @return a valid {@link SubscriberType} that wraps the {@link OnSubscribeType}.
      */
     @NonNull
     protected abstract SubscriberType createSubscriberWrapper(@Nullable OnSubscribeType onSubscribe,

--- a/library/src/main/java/com/anthonycr/bonsai/ObservableAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/ObservableAction.java
@@ -25,7 +25,7 @@ import android.support.annotation.NonNull;
 /**
  * Created by anthonycr on 2/20/17.
  */
-interface Action<T> {
+interface ObservableAction<T> {
 
     /**
      * Should be overridden to send the subscriber

--- a/library/src/main/java/com/anthonycr/bonsai/ObservableOnSubscribe.java
+++ b/library/src/main/java/com/anthonycr/bonsai/ObservableOnSubscribe.java
@@ -20,22 +20,40 @@
  */
 package com.anthonycr.bonsai;
 
+import android.support.annotation.NonNull;
+
 /**
- * When a consumer subscribes to a {@link Completable}
+ * When a consumer subscribes to an {@link Observable}
  * it should supply an implementation of this class
  * with the desired methods overridden.
  * If {@link #onError(Throwable)} is not overridden,
  * it will throw an exception.
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class CompletableOnSubscribe extends ObservableOnSubscribe {
+public abstract class ObservableOnSubscribe {
 
     /**
-     * This method is called when the observer is
-     * finished sending the subscriber events. It
-     * is guaranteed that no other methods will be
-     * called on the OnSubscribe after this method
-     * has been called.
+     * Called when the observable runs into an error
+     * that will cause it to abort and not finish.
+     * Receiving this callback means that the observable
+     * is dead and the subscriber will be unsubscribed.
+     * Default implementation throws an exception,
+     * so you will get a crash if the observable throws
+     * an exception and this method is not overridden.
+     * <p>
+     * Do not call super when you override this method.
+     *
+     * @param throwable an optional throwable that could
+     *                  be sent.
      */
-    public void onComplete() {}
+    public void onError(@NonNull Throwable throwable) {
+        throw new RuntimeException("Exception thrown: override onError to handle it", throwable);
+    }
+
+    /**
+     * Called before the observer begins
+     * to process and emit items or complete.
+     */
+    public void onStart() {}
+
 }

--- a/library/src/main/java/com/anthonycr/bonsai/ObservableSubscriber.java
+++ b/library/src/main/java/com/anthonycr/bonsai/ObservableSubscriber.java
@@ -20,22 +20,36 @@
  */
 package com.anthonycr.bonsai;
 
+import android.support.annotation.NonNull;
+
 /**
- * When a consumer subscribes to a {@link Completable}
- * it should supply an implementation of this class
- * with the desired methods overridden.
- * If {@link #onError(Throwable)} is not overridden,
- * it will throw an exception.
+ * The interface through which the {@link ObservableAction}
+ * communicates to the {@link ObservableOnSubscribe}.
  */
 @SuppressWarnings("WeakerAccess")
-public abstract class CompletableOnSubscribe extends ObservableOnSubscribe {
+public interface ObservableSubscriber extends Subscription {
 
     /**
-     * This method is called when the observer is
-     * finished sending the subscriber events. It
-     * is guaranteed that no other methods will be
-     * called on the OnSubscribe after this method
-     * has been called.
+     * Called immediately upon subscribing
+     * and before the observable begins
+     * emitting items. This should not be
+     * called by the creator of the observable
+     * and is rather called internally by the
+     * observable class itself.
      */
-    public void onComplete() {}
+    void onStart();
+
+    /**
+     * Called when the observable
+     * runs into an error that will
+     * cause it to abort and not finish.
+     * Receiving this callback means that
+     * the observable is dead and will
+     * be unsubscribed.
+     *
+     * @param throwable an optional throwable that could
+     *                  be sent.
+     */
+    void onError(@NonNull Throwable throwable);
+
 }

--- a/library/src/main/java/com/anthonycr/bonsai/ObservableSubscriberWrapper.java
+++ b/library/src/main/java/com/anthonycr/bonsai/ObservableSubscriberWrapper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017 Anthony C. Restaino
+ * <p/>
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.anthonycr.bonsai;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * An implementation of the {@link ObservableSubscriber}
+ * that wraps a {@link ObservableOnSubscribe}, executes
+ * the callbacks on the correct threads, and throws the
+ * appropriate errors when certain rules are violated.
+ */
+@SuppressWarnings("WeakerAccess")
+public class ObservableSubscriberWrapper<T extends ObservableOnSubscribe> implements ObservableSubscriber {
+
+    private volatile boolean onStartExecuted = false;
+    volatile boolean onErrorExecuted = false;
+
+    @Nullable private final Scheduler observerThread;
+    @NonNull private final Scheduler defaultThread;
+    @Nullable protected volatile T onSubscribe;
+
+    public ObservableSubscriberWrapper(@Nullable T onSubscribe,
+                                       @Nullable Scheduler observerThread,
+                                       @NonNull Scheduler defaultThread) {
+        this.onSubscribe = onSubscribe;
+        this.observerThread = observerThread;
+        this.defaultThread = defaultThread;
+    }
+
+    void executeOnObserverThread(@NonNull Runnable runnable) {
+        if (observerThread != null) {
+            observerThread.execute(runnable);
+        } else {
+            defaultThread.execute(runnable);
+        }
+    }
+
+    @Override
+    public void unsubscribe() {
+        onSubscribe = null;
+    }
+
+    @Override
+    public boolean isUnsubscribed() {
+        return onSubscribe == null;
+    }
+
+    @Override
+    public void onStart() {
+        T onSubscribe = this.onSubscribe;
+
+        if (onStartExecuted) {
+            throw new RuntimeException("onStart is called internally, do not call it yourself");
+        } else if (onSubscribe != null) {
+            executeOnObserverThread(new OnStartRunnable(onSubscribe));
+        }
+
+        onStartExecuted = true;
+    }
+
+    @Override
+    public void onError(@NonNull final Throwable throwable) {
+        T onSubscribe = this.onSubscribe;
+
+        if (onSubscribe != null) {
+            executeOnObserverThread(new OnErrorRunnable(onSubscribe, throwable));
+        }
+
+        onErrorExecuted = true;
+
+        unsubscribe();
+    }
+
+}

--- a/library/src/main/java/com/anthonycr/bonsai/OnErrorRunnable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/OnErrorRunnable.java
@@ -23,10 +23,10 @@ package com.anthonycr.bonsai;
 import android.support.annotation.NonNull;
 
 class OnErrorRunnable implements Runnable {
-    @NonNull private final CompletableOnSubscribe onSubscribe;
+    @NonNull private final ObservableOnSubscribe onSubscribe;
     @NonNull private final Throwable throwable;
 
-    OnErrorRunnable(@NonNull CompletableOnSubscribe onSubscribe, @NonNull Throwable throwable) {
+    OnErrorRunnable(@NonNull ObservableOnSubscribe onSubscribe, @NonNull Throwable throwable) {
         this.onSubscribe = onSubscribe;
         this.throwable = throwable;
     }

--- a/library/src/main/java/com/anthonycr/bonsai/OnStartRunnable.java
+++ b/library/src/main/java/com/anthonycr/bonsai/OnStartRunnable.java
@@ -23,9 +23,9 @@ package com.anthonycr.bonsai;
 import android.support.annotation.NonNull;
 
 class OnStartRunnable implements Runnable {
-    @NonNull private final CompletableOnSubscribe onSubscribe;
+    @NonNull private final ObservableOnSubscribe onSubscribe;
 
-    OnStartRunnable(@NonNull CompletableOnSubscribe onSubscribe) {this.onSubscribe = onSubscribe;}
+    OnStartRunnable(@NonNull ObservableOnSubscribe onSubscribe) {this.onSubscribe = onSubscribe;}
 
     @Override
     public void run() {

--- a/library/src/main/java/com/anthonycr/bonsai/Single.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Single.java
@@ -76,9 +76,37 @@ public class Single<T> extends Observable<SingleAction<T>, SingleOnSubscribe<T>,
         });
     }
 
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe work should run on.
+     *
+     * @param subscribeScheduler the {@link Scheduler} to run the work on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Single<T> subscribeOn(@NonNull Scheduler subscribeScheduler) {
+        setActionScheduler(subscribeScheduler);
+        return this;
+    }
+
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe should observe the work on.
+     *
+     * @param observerScheduler the {@link Scheduler} to run to callback on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Single<T> observeOn(@NonNull Scheduler observerScheduler) {
+        setObserverScheduler(observerScheduler);
+        return this;
+    }
+
     @NonNull
     @Override
-    protected SingleSubscriber<T> createSubscriberWrapper(@Nullable SingleOnSubscribe<T> onSubscribe, @Nullable Scheduler observerThread, @NonNull Scheduler defaultThread) {
+    protected SingleSubscriber<T> createSubscriberWrapper(@Nullable SingleOnSubscribe<T> onSubscribe,
+                                                          @Nullable Scheduler observerThread,
+                                                          @NonNull Scheduler defaultThread) {
         return new SingleSubscriberWrapper<>(onSubscribe, observerThread, defaultThread);
     }
 

--- a/library/src/main/java/com/anthonycr/bonsai/SingleAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/SingleAction.java
@@ -27,6 +27,6 @@ package com.anthonycr.bonsai;
  * @param <T> the type the action should emit.
  */
 @SuppressWarnings("WeakerAccess")
-public interface SingleAction<T> extends Action<SingleSubscriber<T>> {
+public interface SingleAction<T> extends ObservableAction<SingleSubscriber<T>> {
 
 }

--- a/library/src/main/java/com/anthonycr/bonsai/SingleAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/SingleAction.java
@@ -20,8 +20,6 @@
  */
 package com.anthonycr.bonsai;
 
-import android.support.annotation.NonNull;
-
 /**
  * An action to perform when a consumer
  * subscribes to the {@link Single}.
@@ -29,16 +27,6 @@ import android.support.annotation.NonNull;
  * @param <T> the type the action should emit.
  */
 @SuppressWarnings("WeakerAccess")
-public interface SingleAction<T> {
+public interface SingleAction<T> extends Action<SingleSubscriber<T>> {
 
-    /**
-     * Should be overridden to send the subscriber
-     * events such as {@link SingleSubscriber#onItem(Object)}
-     * or {@link SingleSubscriber#onComplete()}.
-     *
-     * @param subscriber the subscriber that is sent in
-     *                   when the user of the observable
-     *                   subscribes.
-     */
-    void onSubscribe(@NonNull SingleSubscriber<T> subscriber);
 }

--- a/library/src/main/java/com/anthonycr/bonsai/SingleOnSubscribe.java
+++ b/library/src/main/java/com/anthonycr/bonsai/SingleOnSubscribe.java
@@ -27,7 +27,7 @@ import android.support.annotation.Nullable;
  * it should supply an implementation of this class
  * with the desired methods overridden.
  * If {@link #onError(Throwable)} is not overridden,
- * it will through an exception.
+ * it will throw an exception.
  *
  * @param <T> the type that will be emitted by the action.
  */

--- a/library/src/main/java/com/anthonycr/bonsai/SingleSubscriberWrapper.java
+++ b/library/src/main/java/com/anthonycr/bonsai/SingleSubscriberWrapper.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2017 Anthony C. Restaino
+ * <p/>
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.anthonycr.bonsai;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/anthonycr/bonsai/Stream.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Stream.java
@@ -76,6 +76,32 @@ public class Stream<T> extends Observable<StreamAction<T>, StreamOnSubscribe<T>,
         });
     }
 
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe work should run on.
+     *
+     * @param subscribeScheduler the {@link Scheduler} to run the work on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Stream<T> subscribeOn(@NonNull Scheduler subscribeScheduler) {
+        setActionScheduler(subscribeScheduler);
+        return this;
+    }
+
+    /**
+     * Tells the observable what {@link Scheduler} that
+     * the onSubscribe should observe the work on.
+     *
+     * @param observerScheduler the {@link Scheduler} to run to callback on.
+     * @return returns itself so that calls can be conveniently chained.
+     */
+    @NonNull
+    public final Stream<T> observeOn(@NonNull Scheduler observerScheduler) {
+        setObserverScheduler(observerScheduler);
+        return this;
+    }
+
     @NonNull
     @Override
     protected StreamSubscriber<T> createSubscriberWrapper(@Nullable StreamOnSubscribe<T> onSubscribe,

--- a/library/src/main/java/com/anthonycr/bonsai/Stream.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Stream.java
@@ -20,7 +20,6 @@
  */
 package com.anthonycr.bonsai;
 
-import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -39,26 +38,15 @@ import android.support.annotation.Nullable;
  * @param <T> the type that the stream will emit.
  */
 @SuppressWarnings("WeakerAccess")
-public class Stream<T> {
-
-    @NonNull private final StreamAction<T> action;
-    @NonNull private final Scheduler defaultThread;
-    @Nullable private Scheduler subscriberThread;
-    @Nullable private Scheduler observerThread;
+public class Stream<T> extends Observable<StreamAction<T>, StreamOnSubscribe<T>, StreamSubscriber<T>> {
 
     private Stream(@NonNull StreamAction<T> action) {
-        this.action = action;
-        if (Looper.myLooper() == null) {
-            Looper.prepare();
-        }
-        Looper looper = Looper.myLooper();
-        Preconditions.checkNonNull(looper);
-        defaultThread = new ThreadScheduler(looper);
+        super(action);
     }
 
     /**
      * Static creator method that creates an stream from the
-     * {@link CompletableAction} that is passed in as the parameter. Action
+     * {@link StreamAction} that is passed in as the parameter. Action
      * must not be null.
      *
      * @param action the Action to perform
@@ -88,82 +76,12 @@ public class Stream<T> {
         });
     }
 
-    /**
-     * Tells the stream what Scheduler that the onSubscribe
-     * work should run on.
-     *
-     * @param subscribeScheduler the Scheduler to run the work on.
-     * @return returns this so that calls can be conveniently chained.
-     */
     @NonNull
-    public Stream<T> subscribeOn(@NonNull Scheduler subscribeScheduler) {
-        subscriberThread = subscribeScheduler;
-        return this;
+    @Override
+    protected StreamSubscriber<T> createSubscriberWrapper(@Nullable StreamOnSubscribe<T> onSubscribe,
+                                                          @Nullable Scheduler observerThread,
+                                                          @NonNull Scheduler defaultThread) {
+        return new StreamSubscriberWrapper<>(onSubscribe, observerThread, defaultThread);
     }
-
-    /**
-     * Tells the stream what Scheduler the onSubscribe should observe
-     * the work on.
-     *
-     * @param observerScheduler the Scheduler to run to callback on.
-     * @return returns this so that calls can be conveniently chained.
-     */
-    @NonNull
-    public Stream<T> observeOn(@NonNull Scheduler observerScheduler) {
-        observerThread = observerScheduler;
-        return this;
-    }
-
-    /**
-     * Subscribes immediately to the stream and ignores
-     * all onComplete and onNext calls.
-     */
-    public void subscribe() {
-        startSubscription(null);
-    }
-
-    /**
-     * Immediately subscribes to the stream and starts
-     * sending events from the stream to the {@link StreamOnSubscribe}.
-     *
-     * @param onSubscribe the class that wishes to receive onNext and
-     *                    onComplete callbacks from the stream.
-     */
-    @NonNull
-    public Subscription subscribe(@NonNull StreamOnSubscribe<T> onSubscribe) {
-        Preconditions.checkNonNull(onSubscribe);
-
-        return startSubscription(onSubscribe);
-    }
-
-    @NonNull
-    private Subscription startSubscription(@Nullable StreamOnSubscribe<T> onSubscribe) {
-        final StreamSubscriberWrapper<T> subscriber =
-            new StreamSubscriberWrapper<>(onSubscribe, observerThread, defaultThread);
-
-        subscriber.onStart();
-
-        executeOnSubscriberThread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    action.onSubscribe(subscriber);
-                } catch (Exception exception) {
-                    subscriber.onError(exception);
-                }
-            }
-        });
-
-        return subscriber;
-    }
-
-    private void executeOnSubscriberThread(@NonNull Runnable runnable) {
-        if (subscriberThread != null) {
-            subscriberThread.execute(runnable);
-        } else {
-            defaultThread.execute(runnable);
-        }
-    }
-
 }
 

--- a/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
@@ -20,8 +20,6 @@
  */
 package com.anthonycr.bonsai;
 
-import android.support.annotation.NonNull;
-
 /**
  * An action to perform when a consumer
  * subscribes to the {@link Stream}.
@@ -29,15 +27,6 @@ import android.support.annotation.NonNull;
  * @param <T> the type the action should emit.
  */
 @SuppressWarnings("WeakerAccess")
-public interface StreamAction<T> {
-    /**
-     * Should be overridden to send the subscriber
-     * events such as {@link StreamSubscriber#onNext(Object)}
-     * or {@link StreamSubscriber#onComplete()}.
-     *
-     * @param subscriber the subscriber that is sent in
-     *                   when the user of the observable
-     *                   subscribes.
-     */
-    void onSubscribe(@NonNull StreamSubscriber<T> subscriber);
+public interface StreamAction<T> extends Action<StreamSubscriber<T>> {
+
 }

--- a/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamAction.java
@@ -27,6 +27,6 @@ package com.anthonycr.bonsai;
  * @param <T> the type the action should emit.
  */
 @SuppressWarnings("WeakerAccess")
-public interface StreamAction<T> extends Action<StreamSubscriber<T>> {
+public interface StreamAction<T> extends ObservableAction<StreamSubscriber<T>> {
 
 }

--- a/library/src/main/java/com/anthonycr/bonsai/StreamOnSubscribe.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamOnSubscribe.java
@@ -27,7 +27,7 @@ import android.support.annotation.Nullable;
  * it should supply an implementation of this class
  * with the desired methods overridden.
  * If {@link #onError(Throwable)} is not overridden,
- * it will through an exception.
+ * it will throw an exception.
  *
  * @param <T> the type that will be emitted by the action.
  */

--- a/library/src/main/java/com/anthonycr/bonsai/StreamSubscriberWrapper.java
+++ b/library/src/main/java/com/anthonycr/bonsai/StreamSubscriberWrapper.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2017 Anthony C. Restaino
+ * <p/>
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.anthonycr.bonsai;
 
 import android.support.annotation.NonNull;

--- a/library/src/main/java/com/anthonycr/bonsai/Subscription.java
+++ b/library/src/main/java/com/anthonycr/bonsai/Subscription.java
@@ -35,4 +35,16 @@ public interface Subscription {
      */
     void unsubscribe();
 
+    /**
+     * This method tells the caller whether or not
+     * the subscriber to this observable has unsubscribed
+     * or not. Useful for long running or never ending
+     * operations that would otherwise needlessly use
+     * resources.
+     *
+     * @return true if the the Subscriber has unsubscribed,
+     * false otherwise.
+     */
+    boolean isUnsubscribed();
+
 }


### PR DESCRIPTION
Moving all observable logic out of Completable, Single, and Stream and into Observable.java. Make each observable extend the base Observable class, providing certain type parameters.