### PR TITLE
Testing with mockito

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,6 +21,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.2.2'
+    testCompile 'org.mockito:mockito-core:2.7.19'
 
     compile 'com.android.support:support-annotations:25.3.0'
 }

--- a/library/src/test/java/com/anthonycr/bonsai/BaseUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/BaseUnitTest.java
@@ -15,11 +15,19 @@
  */
 package com.anthonycr.bonsai;
 
+import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 25)
 public abstract class BaseUnitTest {
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
 }

--- a/library/src/test/java/com/anthonycr/bonsai/CompletableSubscriberWrapperTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/CompletableSubscriberWrapperTest.java
@@ -5,6 +5,9 @@ import android.support.annotation.NonNull;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -13,93 +16,42 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class CompletableSubscriberWrapperTest extends BaseUnitTest {
 
+    @Mock
+    private CompletableOnSubscribe completableOnSubscribe;
+
     @Test
     public void onCompleteTest_Succeeds() throws Exception {
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        CompletableOnSubscribe onSubscribe = new CompletableOnSubscribe() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-        };
-        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(completableOnSubscribe, null, Schedulers.current());
         wrapper.onComplete();
 
-        Assert.assertTrue(onCompleteCalled.get());
-        Assert.assertFalse(onStartCalled.get());
-        Assert.assertFalse(onErrorCalled.get());
+        Mockito.verify(completableOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test(expected = RuntimeException.class)
     public void onCompleteTest_calledMultipleTimes_throwsException() throws Exception {
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        CompletableOnSubscribe onSubscribe = new CompletableOnSubscribe() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-        };
-        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(completableOnSubscribe, null, Schedulers.current());
         wrapper.onComplete();
 
-        Assert.assertFalse(onStartCalled.get());
-        Assert.assertTrue(onCompleteCalled.get());
-        Assert.assertFalse(onErrorCalled.get());
+        Mockito.verify(completableOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
 
         wrapper.onComplete();
     }
 
     @Test
     public void onErrorTest_Succeeds_overridden() throws Exception {
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        CompletableOnSubscribe onSubscribe = new CompletableOnSubscribe() {
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
+        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(completableOnSubscribe, null, Schedulers.current());
 
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
+        Exception exception = new Exception("Test exception");
 
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-        };
-        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
-        wrapper.onError(new Exception("Test exception"));
+        wrapper.onError(exception);
 
-        Assert.assertTrue(onErrorCalled.get());
-        Assert.assertFalse(onStartCalled.get());
-        Assert.assertFalse(onCompleteCalled.get());
+        Mockito.verify(completableOnSubscribe).onError(exception);
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test(expected = RuntimeException.class)
@@ -117,86 +69,29 @@ public class CompletableSubscriberWrapperTest extends BaseUnitTest {
 
     @Test
     public void onStartTest_Succeeds() throws Exception {
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        CompletableOnSubscribe onSubscribe = new CompletableOnSubscribe() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-        };
-        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(completableOnSubscribe, null, Schedulers.current());
         wrapper.onStart();
 
-        Assert.assertTrue(onStartCalled.get());
-        Assert.assertFalse(onCompleteCalled.get());
-        Assert.assertFalse(onErrorCalled.get());
+        Mockito.verify(completableOnSubscribe).onStart();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test(expected = RuntimeException.class)
     public void onStartTest_calledMultipleTimes_throwsException() throws Exception {
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        CompletableOnSubscribe onSubscribe = new CompletableOnSubscribe() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-        };
-        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(completableOnSubscribe, null, Schedulers.current());
         wrapper.onStart();
 
-        Assert.assertTrue(onStartCalled.get());
-        Assert.assertFalse(onCompleteCalled.get());
-        Assert.assertFalse(onErrorCalled.get());
+        Mockito.verify(completableOnSubscribe).onStart();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
 
         wrapper.onStart();
     }
 
     @Test
     public void unsubscribeTest() throws Exception {
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        CompletableOnSubscribe onSubscribe = new CompletableOnSubscribe() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-        };
-        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        CompletableSubscriberWrapper<CompletableOnSubscribe> wrapper = new CompletableSubscriberWrapper<>(completableOnSubscribe, null, Schedulers.current());
         wrapper.unsubscribe();
 
         Assert.assertTrue(wrapper.isUnsubscribed());
@@ -205,9 +100,7 @@ public class CompletableSubscriberWrapperTest extends BaseUnitTest {
         wrapper.onComplete();
         wrapper.onError(new Exception("Test exception"));
 
-        Assert.assertFalse(onStartCalled.get());
-        Assert.assertFalse(onCompleteCalled.get());
-        Assert.assertFalse(onErrorCalled.get());
+        Mockito.verifyZeroInteractions(completableOnSubscribe);
     }
 
 }

--- a/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/CompletableUnitTest.java
@@ -24,6 +24,9 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,6 +38,9 @@ import static org.junit.Assert.assertTrue;
 
 public class CompletableUnitTest extends BaseUnitTest {
 
+    @Mock
+    private CompletableOnSubscribe completableOnSubscribe;
+
     @Test
     public void testMainLooperWorking() throws Exception {
         if (Looper.getMainLooper() == null) {
@@ -45,40 +51,23 @@ public class CompletableUnitTest extends BaseUnitTest {
 
     @Test
     public void testCompletableEventEmission_withException() throws Exception {
-        final AtomicReference<Boolean> errorAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> completeAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> startAssertion = new AtomicReference<>(false);
+        final RuntimeException runtimeException = new RuntimeException("Test failure");
 
         Completable.create(new CompletableAction() {
             @Override
             public void onSubscribe(@NonNull CompletableSubscriber subscriber) {
-                throw new RuntimeException("Test failure");
+                throw runtimeException;
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new CompletableOnSubscribe() {
+            .subscribe(completableOnSubscribe);
 
-                @Override
-                public void onStart() {
-                    startAssertion.set(true);
-                }
+        InOrder inOrder = Mockito.inOrder(completableOnSubscribe);
 
-                @Override
-                public void onComplete() {
-                    completeAssertion.set(true);
-                }
+        inOrder.verify(completableOnSubscribe).onStart();
+        inOrder.verify(completableOnSubscribe).onError(runtimeException);
 
-                @Override
-                public void onError(@NonNull Throwable throwable) {
-                    errorAssertion.set(true);
-                }
-            });
-
-        // Assert that each of the events was
-        // received by the subscriber
-        assertTrue(errorAssertion.get());
-        assertTrue(startAssertion.get());
-        assertFalse(completeAssertion.get());
+        Mockito.verify(completableOnSubscribe, Mockito.never()).onComplete();
     }
 
     @Test
@@ -97,15 +86,13 @@ public class CompletableUnitTest extends BaseUnitTest {
 
     @Test
     public void testCompletableEventEmission_withError() throws Exception {
-        final AtomicReference<Boolean> errorAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> completeAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> startAssertion = new AtomicReference<>(false);
+        final Exception exception = new Exception("Test failure");
 
         Completable.create(new CompletableAction() {
             @Override
             public void onSubscribe(@NonNull CompletableSubscriber subscriber) {
                 try {
-                    throw new Exception("Test failure");
+                    throw exception;
                 } catch (Exception e) {
                     subscriber.onError(e);
                 }
@@ -113,37 +100,19 @@ public class CompletableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new CompletableOnSubscribe() {
+            .subscribe(completableOnSubscribe);
 
-                @Override
-                public void onStart() {
-                    startAssertion.set(true);
-                }
+        InOrder inOrder = Mockito.inOrder(completableOnSubscribe);
 
-                @Override
-                public void onComplete() {
-                    completeAssertion.set(true);
-                }
+        inOrder.verify(completableOnSubscribe).onStart();
+        inOrder.verify(completableOnSubscribe).onError(exception);
 
-                @Override
-                public void onError(@NonNull Throwable throwable) {
-                    errorAssertion.set(true);
-                }
-            });
-
-        // Assert that each of the events was
-        // received by the subscriber
-        assertTrue(errorAssertion.get());
-        assertTrue(startAssertion.get());
-        assertFalse(completeAssertion.get());
+        Mockito.verify(completableOnSubscribe, Mockito.never()).onComplete();
     }
 
     @Test
     public void testCompletableEventEmission_withoutError() throws Exception {
         final AtomicReference<Boolean> onSubscribeAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> errorAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> completeAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> startAssertion = new AtomicReference<>(false);
 
         Completable.create(new CompletableAction() {
             @Override
@@ -153,37 +122,24 @@ public class CompletableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new CompletableOnSubscribe() {
-
-                @Override
-                public void onStart() {
-                    startAssertion.set(true);
-                }
-
-                @Override
-                public void onComplete() {
-                    completeAssertion.set(true);
-                }
-
-                @Override
-                public void onError(@NonNull Throwable throwable) {
-                    errorAssertion.set(true);
-                }
-            });
+            .subscribe(completableOnSubscribe);
 
         // Assert that each of the events was
         // received by the subscriber
         assertTrue(onSubscribeAssertion.get());
-        assertFalse(errorAssertion.get());
-        assertTrue(startAssertion.get());
-        assertTrue(completeAssertion.get());
+
+        InOrder inOrder = Mockito.inOrder(completableOnSubscribe);
+
+        inOrder.verify(completableOnSubscribe).onStart();
+        inOrder.verify(completableOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test
     public void testCompletableUnsubscribe_unsubscribesSuccessfully() throws Exception {
         final CountDownLatch subscribeLatch = new CountDownLatch(1);
         final CountDownLatch latch = new CountDownLatch(1);
-        final AtomicReference<Boolean> assertion = new AtomicReference<>(false);
         Subscription stringSubscription = Completable.create(new CompletableAction() {
 
             @Override
@@ -198,18 +154,14 @@ public class CompletableUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.io())
             .observeOn(Schedulers.io())
-            .subscribe(new CompletableOnSubscribe() {
-                @Override
-                public void onComplete() {
-                    assertion.set(true);
-                }
-            });
+            .subscribe(completableOnSubscribe);
 
         stringSubscription.unsubscribe();
         subscribeLatch.countDown();
         latch.await();
 
-        assertFalse(assertion.get());
+        Mockito.verify(completableOnSubscribe).onStart();
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test
@@ -435,9 +387,18 @@ public class CompletableUnitTest extends BaseUnitTest {
                 } catch (Exception exception) {
                     errorThrown.set(true);
                 }
+                subscriber.onComplete();
             }
-        }).subscribe(new CompletableOnSubscribe() {});
+        }).subscribe(completableOnSubscribe);
+
         assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+
+        InOrder inOrder = Mockito.inOrder(completableOnSubscribe);
+
+        inOrder.verify(completableOnSubscribe).onStart();
+        inOrder.verify(completableOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test
@@ -453,6 +414,7 @@ public class CompletableUnitTest extends BaseUnitTest {
                 }
             }
         }).subscribe();
+
         assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
     }
 
@@ -468,6 +430,7 @@ public class CompletableUnitTest extends BaseUnitTest {
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
             .subscribe();
+
         assertTrue("onSubscribe must be called when subscribe is called", isCalledAssertion.get());
     }
 
@@ -484,14 +447,17 @@ public class CompletableUnitTest extends BaseUnitTest {
                     errorThrown.set(true);
                 }
             }
-        }).subscribe(new CompletableOnSubscribe() {
-            @Override
-            public void onComplete() {
+        }).subscribe(completableOnSubscribe);
 
-            }
-        });
         assertTrue("Exception should be thrown in subscribe code if onComplete called more than once",
             errorThrown.get());
+
+        InOrder inOrder = Mockito.inOrder(completableOnSubscribe);
+
+        inOrder.verify(completableOnSubscribe).onStart();
+        inOrder.verify(completableOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test
@@ -508,6 +474,7 @@ public class CompletableUnitTest extends BaseUnitTest {
                 }
             }
         }).subscribe();
+
         assertTrue("Exception should be thrown in subscribe code if onComplete called more than once",
             errorThrown.get());
     }
@@ -531,7 +498,9 @@ public class CompletableUnitTest extends BaseUnitTest {
                 latch.countDown();
             }
         });
+
         latch.await();
+
         assertTrue("Looper should initially be null", looperInitiallyNull.get());
         assertTrue("Looper should be initialized by Completable class", looperFinallyNotNull.get());
     }
@@ -556,16 +525,12 @@ public class CompletableUnitTest extends BaseUnitTest {
                     workAssertion.set(true);
                 }
                 unsubscribed.set(subscriber.isUnsubscribed());
+                subscriber.onComplete();
                 onFinalLatch.countDown();
             }
         }).subscribeOn(Schedulers.newSingleThreadedScheduler())
             .observeOn(Schedulers.newSingleThreadedScheduler())
-            .subscribe(new CompletableOnSubscribe() {
-                @Override
-                public void onComplete() {
-
-                }
-            });
+            .subscribe(completableOnSubscribe);
 
         subscription.unsubscribe();
         latch.countDown();
@@ -573,20 +538,21 @@ public class CompletableUnitTest extends BaseUnitTest {
 
         assertFalse(workAssertion.get());
         assertTrue("isUnsubscribed() was not correct", unsubscribed.get());
+
+        Mockito.verify(completableOnSubscribe).onStart();
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
     @Test
     public void testCompletableEmpty_emitsNothingImmediately() throws Exception {
-        final AtomicReference<Boolean> onCompleteAssertion = new AtomicReference<>(false);
-        Completable.empty().subscribe(new CompletableOnSubscribe() {
-            @Override
-            public void onComplete() {
-                onCompleteAssertion.set(true);
-            }
+        Completable.empty().subscribe(completableOnSubscribe);
 
-        });
+        InOrder inOrder = Mockito.inOrder(completableOnSubscribe);
 
-        assertTrue(onCompleteAssertion.get());
+        inOrder.verify(completableOnSubscribe).onStart();
+        inOrder.verify(completableOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(completableOnSubscribe);
     }
 
 }

--- a/library/src/test/java/com/anthonycr/bonsai/OnSubscribeUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/OnSubscribeUnitTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Modifier;
 
-public class OnSubscribeUnitTest extends BaseUnitTest{
+public class OnSubscribeUnitTest extends BaseUnitTest {
 
     @Test
     public void testClassType() throws Exception {

--- a/library/src/test/java/com/anthonycr/bonsai/PreconditionsUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/PreconditionsUnitTest.java
@@ -22,7 +22,7 @@ package com.anthonycr.bonsai;
 
 import org.junit.Test;
 
-public class PreconditionsUnitTest extends BaseUnitTest{
+public class PreconditionsUnitTest extends BaseUnitTest {
 
     @Test
     public void testClassIsFinal() throws Exception {

--- a/library/src/test/java/com/anthonycr/bonsai/SingleSubscriberWrapperTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/SingleSubscriberWrapperTest.java
@@ -34,7 +34,8 @@ public class SingleSubscriberWrapperTest extends BaseUnitTest {
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onItem(itemToBeEmitted);
         inOrder.verify(stringSingleOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
 
     }
 
@@ -50,7 +51,8 @@ public class SingleSubscriberWrapperTest extends BaseUnitTest {
 
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
 
         wrapper.onItem(itemToBeEmitted);
     }
@@ -67,7 +69,8 @@ public class SingleSubscriberWrapperTest extends BaseUnitTest {
 
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onItem(itemToBeEmitted);
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
 
         wrapper.onItem(itemToBeEmitted);
     }

--- a/library/src/test/java/com/anthonycr/bonsai/SingleSubscriberWrapperTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/SingleSubscriberWrapperTest.java
@@ -6,6 +6,9 @@ import android.support.annotation.Nullable;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -14,148 +17,66 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class SingleSubscriberWrapperTest extends BaseUnitTest {
 
+    @Mock
+    private SingleOnSubscribe<String> stringSingleOnSubscribe;
+
     @Test
     public void onItemTest_Succeeds() throws Exception {
         final String itemToBeEmitted = "test";
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        final AtomicReference<String> emittedItem = new AtomicReference<>(null);
 
-        SingleOnSubscribe<String> onSubscribe = new SingleOnSubscribe<String>() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onItem(@Nullable String item) {
-                emittedItem.set(item);
-            }
-        };
-        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(stringSingleOnSubscribe, null, Schedulers.current());
         wrapper.onStart();
         wrapper.onItem(itemToBeEmitted);
         wrapper.onComplete();
 
-        Assert.assertTrue(onCompleteCalled.get());
-        Assert.assertTrue(onStartCalled.get());
-        Assert.assertFalse(onErrorCalled.get());
-        Assert.assertEquals(itemToBeEmitted, emittedItem.get());
+        InOrder inOrder = Mockito.inOrder(stringSingleOnSubscribe);
+
+        inOrder.verify(stringSingleOnSubscribe).onStart();
+        inOrder.verify(stringSingleOnSubscribe).onItem(itemToBeEmitted);
+        inOrder.verify(stringSingleOnSubscribe).onComplete();
+        inOrder.verifyNoMoreInteractions();
 
     }
 
     @Test(expected = RuntimeException.class)
     public void onItemTest_Fails_calledAfterOnComplete() throws Exception {
         final String itemToBeEmitted = "test";
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        final AtomicReference<String> emittedItem = new AtomicReference<>(null);
 
-        SingleOnSubscribe<String> onSubscribe = new SingleOnSubscribe<String>() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onItem(@Nullable String item) {
-                emittedItem.set(item);
-            }
-        };
-        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(stringSingleOnSubscribe, null, Schedulers.current());
         wrapper.onStart();
         wrapper.onComplete();
+
+        InOrder inOrder = Mockito.inOrder(stringSingleOnSubscribe);
+
+        inOrder.verify(stringSingleOnSubscribe).onStart();
+        inOrder.verify(stringSingleOnSubscribe).onComplete();
+        inOrder.verifyNoMoreInteractions();
+
         wrapper.onItem(itemToBeEmitted);
     }
 
     @Test(expected = RuntimeException.class)
     public void onItemTest_Fails_calledMultipleTimes() throws Exception {
         final String itemToBeEmitted = "test";
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        final AtomicReference<String> emittedItem = new AtomicReference<>(null);
 
-        SingleOnSubscribe<String> onSubscribe = new SingleOnSubscribe<String>() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onItem(@Nullable String item) {
-                emittedItem.set(item);
-            }
-        };
-        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(stringSingleOnSubscribe, null, Schedulers.current());
         wrapper.onStart();
         wrapper.onItem(itemToBeEmitted);
+
+        InOrder inOrder = Mockito.inOrder(stringSingleOnSubscribe);
+
+        inOrder.verify(stringSingleOnSubscribe).onStart();
+        inOrder.verify(stringSingleOnSubscribe).onItem(itemToBeEmitted);
+        inOrder.verifyNoMoreInteractions();
+
         wrapper.onItem(itemToBeEmitted);
-        wrapper.onComplete();
     }
 
     @Test
     public void unsubscribe_itemNotEmitted() throws Exception {
         final String itemToBeEmitted = "test";
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onErrorCalled = new AtomicReference<>(false);
-        final AtomicReference<String> emittedItem = new AtomicReference<>(null);
 
-        SingleOnSubscribe<String> onSubscribe = new SingleOnSubscribe<String>() {
-            @Override
-            public void onError(@NonNull Throwable throwable) {
-                onErrorCalled.set(true);
-            }
-
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onItem(@Nullable String item) {
-                emittedItem.set(item);
-            }
-        };
-        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        SingleSubscriberWrapper<String> wrapper = new SingleSubscriberWrapper<>(stringSingleOnSubscribe, null, Schedulers.current());
         wrapper.onStart();
 
         // Unsubscribe after onStart
@@ -164,12 +85,9 @@ public class SingleSubscriberWrapperTest extends BaseUnitTest {
         wrapper.onItem(itemToBeEmitted);
         wrapper.onComplete();
 
-        Assert.assertTrue(onStartCalled.get());
+        Mockito.verify(stringSingleOnSubscribe).onStart();
 
-        // Unsubscribed so the following assertions should be made
-        Assert.assertFalse(onCompleteCalled.get());
-        Assert.assertFalse(onErrorCalled.get());
-        Assert.assertNull(emittedItem.get());
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
 }

--- a/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/SingleUnitTest.java
@@ -160,7 +160,8 @@ public class SingleUnitTest extends BaseUnitTest {
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onItem(testItem);
         inOrder.verify(stringSingleOnSubscribe).onError(runtimeException);
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
     @Test
@@ -188,7 +189,8 @@ public class SingleUnitTest extends BaseUnitTest {
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onItem(testItem);
         inOrder.verify(stringSingleOnSubscribe).onError(exception);
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
     @Test
@@ -210,7 +212,8 @@ public class SingleUnitTest extends BaseUnitTest {
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onItem(testItem);
         inOrder.verify(stringSingleOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
     @Test
@@ -231,7 +234,8 @@ public class SingleUnitTest extends BaseUnitTest {
         InOrder inOrder = Mockito.inOrder(stringSingleOnSubscribe);
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onError(throwableReference.get());
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
     @Test
@@ -587,7 +591,8 @@ public class SingleUnitTest extends BaseUnitTest {
 
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
     @Test
@@ -631,7 +636,8 @@ public class SingleUnitTest extends BaseUnitTest {
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onItem(null);
         inOrder.verify(stringSingleOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
     @Test
@@ -655,7 +661,8 @@ public class SingleUnitTest extends BaseUnitTest {
 
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
     @Test
@@ -726,7 +733,8 @@ public class SingleUnitTest extends BaseUnitTest {
 
         inOrder.verify(stringSingleOnSubscribe).onStart();
         inOrder.verify(stringSingleOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringSingleOnSubscribe);
     }
 
 }

--- a/library/src/test/java/com/anthonycr/bonsai/StreamSubscriberWrapperTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamSubscriberWrapperTest.java
@@ -5,6 +5,9 @@ import android.support.annotation.Nullable;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,33 +19,15 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class StreamSubscriberWrapperTest extends BaseUnitTest {
 
+    @Mock
+    private StreamOnSubscribe<String> stringStreamOnSubscribe;
+
     @Test
     public void onNextTest_Succeeds() throws Exception {
 
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-
         List<String> testList = Arrays.asList("one", "two", "three", "four", "five");
 
-        final List<String> subscriptionList = new ArrayList<>(testList.size());
-
-        StreamOnSubscribe<String> onSubscribe = new StreamOnSubscribe<String>() {
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onNext(@Nullable String item) {
-                subscriptionList.add(item);
-            }
-        };
-        StreamSubscriberWrapper<String> wrapper = new StreamSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        StreamSubscriberWrapper<String> wrapper = new StreamSubscriberWrapper<>(stringStreamOnSubscribe, null, Schedulers.current());
 
         wrapper.onStart();
         for (String item : testList) {
@@ -50,40 +35,32 @@ public class StreamSubscriberWrapperTest extends BaseUnitTest {
         }
         wrapper.onComplete();
 
-        Assert.assertTrue(onStartCalled.get());
-        Assert.assertTrue(onCompleteCalled.get());
-        Assert.assertEquals(testList, subscriptionList);
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
+
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(0));
+        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(1));
+        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(2));
+        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(3));
+        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(4));
+        inOrder.verify(stringStreamOnSubscribe).onComplete();
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test(expected = RuntimeException.class)
     public void onNextTest_Fails_calledAfterOnComplete() throws Exception {
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-
         List<String> testList = Arrays.asList("one", "two", "three", "four", "five");
 
-        final List<String> subscriptionList = new ArrayList<>(testList.size());
-
-        StreamOnSubscribe<String> onSubscribe = new StreamOnSubscribe<String>() {
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onNext(@Nullable String item) {
-                subscriptionList.add(item);
-            }
-        };
-        StreamSubscriberWrapper<String> wrapper = new StreamSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        StreamSubscriberWrapper<String> wrapper = new StreamSubscriberWrapper<>(stringStreamOnSubscribe, null, Schedulers.current());
 
         wrapper.onStart();
         wrapper.onComplete();
+
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
+
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        inOrder.verify(stringStreamOnSubscribe).onComplete();
+        inOrder.verifyNoMoreInteractions();
 
         for (String item : testList) {
             wrapper.onNext(item);
@@ -92,31 +69,9 @@ public class StreamSubscriberWrapperTest extends BaseUnitTest {
 
     @Test
     public void unsubscribe_itemsNotEmitted() throws Exception {
-
-        final AtomicReference<Boolean> onStartCalled = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onCompleteCalled = new AtomicReference<>(false);
-
         List<String> testList = Arrays.asList("one", "two", "three", "four", "five");
 
-        final List<String> subscriptionList = new ArrayList<>(testList.size());
-
-        StreamOnSubscribe<String> onSubscribe = new StreamOnSubscribe<String>() {
-            @Override
-            public void onStart() {
-                onStartCalled.set(true);
-            }
-
-            @Override
-            public void onComplete() {
-                onCompleteCalled.set(true);
-            }
-
-            @Override
-            public void onNext(@Nullable String item) {
-                subscriptionList.add(item);
-            }
-        };
-        StreamSubscriberWrapper<String> wrapper = new StreamSubscriberWrapper<>(onSubscribe, null, Schedulers.current());
+        StreamSubscriberWrapper<String> wrapper = new StreamSubscriberWrapper<>(stringStreamOnSubscribe, null, Schedulers.current());
 
         wrapper.onStart();
 
@@ -132,10 +87,11 @@ public class StreamSubscriberWrapperTest extends BaseUnitTest {
         }
         wrapper.onComplete();
 
-        Assert.assertTrue(onStartCalled.get());
-        Assert.assertFalse(onCompleteCalled.get());
-        Assert.assertTrue(subscriptionList.size() == 1);
-        Assert.assertTrue(subscriptionList.get(0).equals(onlyItem));
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
+
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        inOrder.verify(stringStreamOnSubscribe).onNext(onlyItem);
+        inOrder.verifyNoMoreInteractions();
     }
 
 }

--- a/library/src/test/java/com/anthonycr/bonsai/StreamSubscriberWrapperTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamSubscriberWrapperTest.java
@@ -38,13 +38,12 @@ public class StreamSubscriberWrapperTest extends BaseUnitTest {
         InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
 
         inOrder.verify(stringStreamOnSubscribe).onStart();
-        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(0));
-        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(1));
-        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(2));
-        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(3));
-        inOrder.verify(stringStreamOnSubscribe).onNext(testList.get(4));
+        for (String item : testList) {
+            inOrder.verify(stringStreamOnSubscribe).onNext(item);
+        }
         inOrder.verify(stringStreamOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
     @Test(expected = RuntimeException.class)
@@ -60,7 +59,8 @@ public class StreamSubscriberWrapperTest extends BaseUnitTest {
 
         inOrder.verify(stringStreamOnSubscribe).onStart();
         inOrder.verify(stringStreamOnSubscribe).onComplete();
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
 
         for (String item : testList) {
             wrapper.onNext(item);
@@ -91,7 +91,8 @@ public class StreamSubscriberWrapperTest extends BaseUnitTest {
 
         inOrder.verify(stringStreamOnSubscribe).onStart();
         inOrder.verify(stringStreamOnSubscribe).onNext(onlyItem);
-        inOrder.verifyNoMoreInteractions();
+
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
 }

--- a/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
@@ -24,9 +24,14 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -41,6 +46,9 @@ import static org.junit.Assert.assertTrue;
  */
 public class StreamUnitTest extends BaseUnitTest {
 
+    @Mock
+    private StreamOnSubscribe<String> stringStreamOnSubscribe;
+
     @Test
     public void testMainLooperWorking() throws Exception {
         if (Looper.getMainLooper() == null) {
@@ -51,101 +59,68 @@ public class StreamUnitTest extends BaseUnitTest {
 
     @Test
     public void testStreamEmissionOrder_singleThread() throws Exception {
-        final int testCount = 7;
+        final List<String> testList = Arrays.asList("1", "2", "3", "4", "5", "6", "7");
 
-        final List<String> list = new ArrayList<>(testCount);
         Stream.create(new StreamAction<String>() {
             @Override
             public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
-                for (int n = 0; n < testCount; n++) {
-                    subscriber.onNext(String.valueOf(n));
+                for (String item : testList) {
+                    subscriber.onNext(item);
                 }
                 subscriber.onComplete();
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new StreamOnSubscribe<String>() {
-                @Override
-                public void onNext(@Nullable String item) {
-                    list.add(item);
-                }
+            .subscribe(stringStreamOnSubscribe);
 
-            });
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
 
-        assertTrue(list.size() == testCount);
-        for (int n = 0; n < list.size(); n++) {
-            assertTrue(String.valueOf(n).equals(list.get(n)));
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        for (String item : testList) {
+            inOrder.verify(stringStreamOnSubscribe).onNext(item);
         }
+        inOrder.verify(stringStreamOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
     @Test
     public void testStreamEventEmission_withException() throws Exception {
-        final int testCount = 7;
+        final List<String> testList = Arrays.asList("1", "2", "3", "4", "5", "6", "7");
+        final RuntimeException runtimeException = new RuntimeException("Test failure");
 
-        final AtomicReference<Boolean> errorAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> nextAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> completeAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> startAssertion = new AtomicReference<>(false);
-
-        final List<String> list = new ArrayList<>(testCount);
         Stream.create(new StreamAction<String>() {
             @Override
             public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
-                for (int n = 0; n < testCount; n++) {
-                    subscriber.onNext(String.valueOf(n));
+                for (String item : testList) {
+                    subscriber.onNext(item);
                 }
-                throw new RuntimeException("Test failure");
+                throw runtimeException;
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new StreamOnSubscribe<String>() {
+            .subscribe(stringStreamOnSubscribe);
 
-                @Override
-                public void onStart() {
-                    startAssertion.set(true);
-                }
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
 
-                @Override
-                public void onNext(@Nullable String item) {
-                    nextAssertion.set(true);
-                    list.add(item);
-                }
-
-                @Override
-                public void onComplete() {
-                    completeAssertion.set(true);
-                }
-
-                @Override
-                public void onError(@NonNull Throwable throwable) {
-                    errorAssertion.set(true);
-                }
-            });
-
-        // Even though error has been broadcast,
-        // stream should still complete.
-        assertTrue(list.size() == testCount);
-        for (int n = 0; n < list.size(); n++) {
-            assertTrue(String.valueOf(n).equals(list.get(n)));
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        for (String item : testList) {
+            inOrder.verify(stringStreamOnSubscribe).onNext(item);
         }
+        inOrder.verify(stringStreamOnSubscribe).onError(runtimeException);
 
-        // Assert that each of the events was
-        // received by the subscriber
-        assertTrue(errorAssertion.get());
-        assertTrue(startAssertion.get());
-        assertFalse(completeAssertion.get());
-        assertTrue(nextAssertion.get());
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
     @Test
     public void testStreamEventEmission_withoutSubscriber_withException() throws Exception {
-        final int testCount = 7;
+        final List<String> testList = Arrays.asList("1", "2", "3", "4", "5", "6", "7");
 
         Stream.create(new StreamAction<String>() {
             @Override
             public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
-                for (int n = 0; n < testCount; n++) {
-                    subscriber.onNext(String.valueOf(n));
+                for (String item : testList) {
+                    subscriber.onNext(item);
                 }
                 throw new RuntimeException("Test failure");
             }
@@ -158,22 +133,17 @@ public class StreamUnitTest extends BaseUnitTest {
 
     @Test
     public void testStreamEventEmission_withError() throws Exception {
-        final int testCount = 7;
+        final List<String> testList = Arrays.asList("1", "2", "3", "4", "5", "6", "7");
+        final Exception exception = new Exception("Test failure");
 
-        final AtomicReference<Boolean> errorAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> nextAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> completeAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> startAssertion = new AtomicReference<>(false);
-
-        final List<String> list = new ArrayList<>(testCount);
         Stream.create(new StreamAction<String>() {
             @Override
             public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
-                for (int n = 0; n < testCount; n++) {
-                    subscriber.onNext(String.valueOf(n));
+                for (String item : testList) {
+                    subscriber.onNext(item);
                 }
                 try {
-                    throw new Exception("Test failure");
+                    throw exception;
                 } catch (Exception e) {
                     subscriber.onError(e);
                 }
@@ -181,102 +151,17 @@ public class StreamUnitTest extends BaseUnitTest {
             }
         }).subscribeOn(Schedulers.current())
             .observeOn(Schedulers.current())
-            .subscribe(new StreamOnSubscribe<String>() {
+            .subscribe(stringStreamOnSubscribe);
 
-                @Override
-                public void onStart() {
-                    startAssertion.set(true);
-                }
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
 
-                @Override
-                public void onNext(@Nullable String item) {
-                    nextAssertion.set(true);
-                    list.add(item);
-                }
-
-                @Override
-                public void onComplete() {
-                    completeAssertion.set(true);
-                }
-
-                @Override
-                public void onError(@NonNull Throwable throwable) {
-                    errorAssertion.set(true);
-                }
-            });
-
-        // Even though error has been broadcast,
-        // stream should still complete.
-        assertTrue(list.size() == testCount);
-        for (int n = 0; n < list.size(); n++) {
-            assertTrue(String.valueOf(n).equals(list.get(n)));
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        for (String item : testList) {
+            inOrder.verify(stringStreamOnSubscribe).onNext(item);
         }
+        inOrder.verify(stringStreamOnSubscribe).onError(exception);
 
-        // Assert that each of the events was
-        // received by the subscriber
-        assertTrue(errorAssertion.get());
-        assertTrue(startAssertion.get());
-        assertFalse(completeAssertion.get());
-        assertTrue(nextAssertion.get());
-    }
-
-    @Test
-    public void testStreamEventEmission_withoutError() throws Exception {
-        final int testCount = 7;
-
-        final AtomicReference<Boolean> errorAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> nextAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> completeAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> startAssertion = new AtomicReference<>(false);
-
-        final List<String> list = new ArrayList<>(testCount);
-        Stream.create(new StreamAction<String>() {
-            @Override
-            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
-                for (int n = 0; n < testCount; n++) {
-                    subscriber.onNext(String.valueOf(n));
-                }
-                subscriber.onComplete();
-            }
-        }).subscribeOn(Schedulers.current())
-            .observeOn(Schedulers.current())
-            .subscribe(new StreamOnSubscribe<String>() {
-
-                @Override
-                public void onStart() {
-                    startAssertion.set(true);
-                }
-
-                @Override
-                public void onNext(@Nullable String item) {
-                    nextAssertion.set(true);
-                    list.add(item);
-                }
-
-                @Override
-                public void onComplete() {
-                    completeAssertion.set(true);
-                }
-
-                @Override
-                public void onError(@NonNull Throwable throwable) {
-                    errorAssertion.set(true);
-                }
-            });
-
-        // Even though error has been broadcast,
-        // stream should still complete.
-        assertTrue(list.size() == testCount);
-        for (int n = 0; n < list.size(); n++) {
-            assertTrue(String.valueOf(n).equals(list.get(n)));
-        }
-
-        // Assert that each of the events was
-        // received by the subscriber
-        assertFalse(errorAssertion.get());
-        assertTrue(startAssertion.get());
-        assertTrue(completeAssertion.get());
-        assertTrue(nextAssertion.get());
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
     @Test
@@ -597,21 +482,28 @@ public class StreamUnitTest extends BaseUnitTest {
 
     @Test
     public void testStreamThrowsException_onCompleteCalledTwice() throws Exception {
-        final AtomicReference<Boolean> errorThrown = new AtomicReference<>(false);
-        Stream.create(new StreamAction<Object>() {
+        final AtomicReference<Throwable> thrownException = new AtomicReference<>(null);
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 try {
                     subscriber.onComplete();
                     subscriber.onComplete();
                 } catch (RuntimeException e) {
-                    errorThrown.set(true);
+                    thrownException.set(e);
+                    throw e;
                 }
             }
-        }).subscribe(new StreamOnSubscribe<Object>() {
-        });
-        assertTrue("Exception should be thrown in subscribe code if onComplete called more than once",
-            errorThrown.get());
+        }).subscribe(stringStreamOnSubscribe);
+
+        Assert.assertNotNull(thrownException.get());
+
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
+
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        inOrder.verify(stringStreamOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
     @Test
@@ -634,18 +526,25 @@ public class StreamUnitTest extends BaseUnitTest {
 
     @Test
     public void testStreamThrowsException_onStartCalled() throws Exception {
-        final AtomicReference<Boolean> errorThrown = new AtomicReference<>(false);
-        Stream.create(new StreamAction<Object>() {
+        final AtomicReference<Throwable> thrownException = new AtomicReference<>(null);
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 try {
                     subscriber.onStart();
                 } catch (Exception exception) {
-                    errorThrown.set(true);
+                    thrownException.set(exception);
+                    throw exception;
                 }
             }
-        }).subscribe(new StreamOnSubscribe<Object>() {});
-        assertTrue("Exception should be thrown in subscribe code if onStart is called", errorThrown.get());
+        }).subscribe(stringStreamOnSubscribe);
+
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
+
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        inOrder.verify(stringStreamOnSubscribe).onError(thrownException.get());
+
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
     @Test
@@ -667,9 +566,9 @@ public class StreamUnitTest extends BaseUnitTest {
     @Test
     public void testStreamThrowsException_onNextCalledAfterOnComplete() throws Exception {
         final AtomicReference<Boolean> errorThrown = new AtomicReference<>(false);
-        Stream.create(new StreamAction<Object>() {
+        Stream.create(new StreamAction<String>() {
             @Override
-            public void onSubscribe(@NonNull StreamSubscriber<Object> subscriber) {
+            public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
                 try {
                     subscriber.onComplete();
                     subscriber.onNext(null);
@@ -677,8 +576,16 @@ public class StreamUnitTest extends BaseUnitTest {
                     errorThrown.set(true);
                 }
             }
-        }).subscribe(new StreamOnSubscribe<Object>() {});
+        }).subscribe(stringStreamOnSubscribe);
+
         assertTrue("Exception should be thrown in subscribe code if onNext called after onComplete", errorThrown.get());
+
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
+
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        inOrder.verify(stringStreamOnSubscribe).onComplete();
+
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
     @Test
@@ -749,24 +656,15 @@ public class StreamUnitTest extends BaseUnitTest {
 
     @Test
     public void testStreamEmpty_emitsNothingImmediately() throws Exception {
-        final AtomicReference<Boolean> onNextAssertion = new AtomicReference<>(false);
-        final AtomicReference<Boolean> onCompleteAssertion = new AtomicReference<>(false);
-        Stream.empty().subscribe(new StreamOnSubscribe<Object>() {
+        Stream<String> stream = Stream.empty();
+        stream.subscribe(stringStreamOnSubscribe);
 
-            @Override
-            public void onNext(@Nullable Object item) {
-                onNextAssertion.set(true);
-            }
+        InOrder inOrder = Mockito.inOrder(stringStreamOnSubscribe);
 
-            @Override
-            public void onComplete() {
-                onCompleteAssertion.set(true);
-            }
+        inOrder.verify(stringStreamOnSubscribe).onStart();
+        inOrder.verify(stringStreamOnSubscribe).onComplete();
 
-        });
-
-        assertFalse(onNextAssertion.get());
-        assertTrue(onCompleteAssertion.get());
+        Mockito.verifyNoMoreInteractions(stringStreamOnSubscribe);
     }
 
 }

--- a/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
+++ b/library/src/test/java/com/anthonycr/bonsai/StreamUnitTest.java
@@ -288,11 +288,7 @@ public class StreamUnitTest extends BaseUnitTest {
 
             @Override
             public void onSubscribe(@NonNull StreamSubscriber<String> subscriber) {
-                try {
-                    subscribeLatch.await();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+                Utils.safeWait(subscribeLatch);
                 subscriber.onNext("test");
                 latch.countDown();
             }
@@ -723,11 +719,7 @@ public class StreamUnitTest extends BaseUnitTest {
                 if (!subscriber.isUnsubscribed()) {
                     subscriber.onNext("test 1");
                 }
-                try {
-                    latch.await();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+                Utils.safeWait(latch);
                 // should be unsubscribed after the latch countdown occurs
                 if (!subscriber.isUnsubscribed()) {
                     subscriber.onNext("test 2");

--- a/library/src/test/java/com/anthonycr/bonsai/Utils.java
+++ b/library/src/test/java/com/anthonycr/bonsai/Utils.java
@@ -28,6 +28,7 @@ import junit.framework.Assert;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
+import java.util.concurrent.CountDownLatch;
 
 public class Utils {
 
@@ -69,6 +70,14 @@ public class Utils {
 
     public static void log(@NonNull CharSequence message) {
         log(DEFAULT_LOG_TAG, message);
+    }
+
+    public static void safeWait(@NonNull CountDownLatch countDownLatch) {
+        try {
+            countDownLatch.await();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
 }


### PR DESCRIPTION
Simplifying most unit tests by using mockito to mock the `[Observable]OnSubscribe] callbacks instead of creating my own and using `AtomicReferences` to verify that methods were called. An added benefit of this is that I'm now able to verify the order that things are called in. Almost all synchronous tests were able to benefit from using mockito, asynchronous tests that used countdown latches were not switched to mockito.